### PR TITLE
fix: pin magit-process buffers to magit slot when layout active

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -155,7 +155,7 @@ Note: `C-c LETTER` is reserved for users per GNU conventions. The package define
   - Transient buffers (diff, log) **replace** status in the same window
   - Pressing `q` restores previous buffer via magit's built-in `quit-restore` — no custom restoration needed
 - [ ] `COMMIT_EDITMSG` → route to the **editor pane** via `display-buffer-alist` (commits are editing tasks)
-- [ ] `magit-process` → stays in magit slot or hidden
+- [x] `magit-process` → stays in magit slot or hidden
 - [ ] `knayawp--setup-magit-integration` / `knayawp--teardown-magit-integration`
 - [ ] `defcustom knayawp-magit-commit-in-editor-p` (default t) — whether commit messages open in editor pane
 

--- a/knayawp.el
+++ b/knayawp.el
@@ -111,6 +111,10 @@ Each BUFFER-ALIST maps panel types to their buffers.")
   "The `display-buffer-alist' entry for COMMIT_EDITMSG routing.
 Stored so it can be cleanly removed on teardown.")
 
+(defvar knayawp--process-display-entry nil
+  "The `display-buffer-alist' entry for `magit-process-mode' routing.
+Stored so it can be cleanly removed on teardown.")
+
 ;;;; Project detection
 
 (defun knayawp--project-root ()
@@ -268,13 +272,28 @@ previously active `magit-display-buffer-function'."
           . ((no-delete-other-windows . t)
              (no-other-window . t))))))))
 
+(defun knayawp--magit-process-buffer-p (buffer-or-name _action)
+  "Return non-nil if BUFFER-OR-NAME is a `magit-process-mode' buffer.
+Used as a `display-buffer-alist' condition.  Only matches when a
+knayawp magit side window currently exists in the selected frame,
+so the routing is a no-op when no layout is active."
+  (when-let* ((magit-spec (assq 'magit knayawp-panels))
+              ((knayawp--side-window-for-slot
+                (knayawp--panel-slot magit-spec))))
+    (let ((buf (get-buffer buffer-or-name)))
+      (and buf
+           (with-current-buffer buf
+             (derived-mode-p 'magit-process-mode))))))
+
 (defun knayawp--setup-magit-integration ()
   "Install magit buffer display integration.
 Save the current `magit-display-buffer-function' and replace it
 with `knayawp--magit-display-buffer'.  If
 `knayawp-magit-commit-in-editor-flag' is non-nil, add a
 `display-buffer-alist' entry to route COMMIT_EDITMSG to the
-editor pane."
+editor pane.  Also add an entry that pins `magit-process-mode'
+buffers to the magit side window so long-running git commands do
+not pop a window in the editor pane."
   (when (require 'magit nil t)
     ;; Guard against double-setup: only save the original function
     ;; if we haven't already installed ours.
@@ -292,12 +311,27 @@ editor pane."
                display-buffer-use-some-window)
               (reusable-frames . visible)
               (inhibit-same-window . t)))
-      (push knayawp--commit-display-entry display-buffer-alist))))
+      (push knayawp--commit-display-entry display-buffer-alist))
+    (unless knayawp--process-display-entry
+      (let ((slot (knayawp--panel-slot
+                   (assq 'magit knayawp-panels))))
+        (setq knayawp--process-display-entry
+              `(knayawp--magit-process-buffer-p
+                (display-buffer-in-side-window)
+                (side . right)
+                (slot . ,slot)
+                (window-width . ,knayawp-right-width)
+                (preserve-size . (t . nil))
+                (window-parameters
+                 . ((no-delete-other-windows . t)
+                    (no-other-window . t)))))
+        (push knayawp--process-display-entry display-buffer-alist)))))
 
 (defun knayawp--teardown-magit-integration ()
   "Remove magit buffer display integration.
 Restore the saved `magit-display-buffer-function' and remove the
-COMMIT_EDITMSG `display-buffer-alist' entry."
+COMMIT_EDITMSG and `magit-process-mode' `display-buffer-alist'
+entries."
   (when knayawp--magit-saved-display-fn
     (setq magit-display-buffer-function
           knayawp--magit-saved-display-fn)
@@ -305,7 +339,11 @@ COMMIT_EDITMSG `display-buffer-alist' entry."
   (when knayawp--commit-display-entry
     (setq display-buffer-alist
           (delq knayawp--commit-display-entry display-buffer-alist))
-    (setq knayawp--commit-display-entry nil)))
+    (setq knayawp--commit-display-entry nil))
+  (when knayawp--process-display-entry
+    (setq display-buffer-alist
+          (delq knayawp--process-display-entry display-buffer-alist))
+    (setq knayawp--process-display-entry nil)))
 
 ;;;; Layout engine
 

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -245,10 +245,12 @@
 (ert-deftest knayawp-test-magit-teardown-idempotent ()
   "Tearing down magit integration when not set up is safe."
   (let ((knayawp--magit-saved-display-fn nil)
-        (knayawp--commit-display-entry nil))
+        (knayawp--commit-display-entry nil)
+        (knayawp--process-display-entry nil))
     (knayawp--teardown-magit-integration)
     (should-not knayawp--magit-saved-display-fn)
-    (should-not knayawp--commit-display-entry)))
+    (should-not knayawp--commit-display-entry)
+    (should-not knayawp--process-display-entry)))
 
 (ert-deftest knayawp-test-magit-setup-teardown-roundtrip ()
   "Setup then teardown restores original display function."
@@ -256,6 +258,7 @@
     (let ((original magit-display-buffer-function)
           (knayawp--magit-saved-display-fn nil)
           (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
           (display-buffer-alist display-buffer-alist))
       (unwind-protect
           (progn
@@ -265,7 +268,8 @@
             (should knayawp--magit-saved-display-fn)
             (knayawp--teardown-magit-integration)
             (should (eq magit-display-buffer-function original))
-            (should-not knayawp--magit-saved-display-fn))
+            (should-not knayawp--magit-saved-display-fn)
+            (should-not knayawp--process-display-entry))
         ;; Safety restore
         (setq magit-display-buffer-function original)))))
 
@@ -275,6 +279,7 @@
     (let ((original magit-display-buffer-function)
           (knayawp--magit-saved-display-fn nil)
           (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
           (knayawp-magit-commit-in-editor-flag t)
           (display-buffer-alist nil))
       (unwind-protect
@@ -284,8 +289,9 @@
             ;; Second setup must not overwrite the saved function
             (knayawp--setup-magit-integration)
             (should (eq knayawp--magit-saved-display-fn original))
-            ;; display-buffer-alist must not have duplicates
-            (should (= 1 (length display-buffer-alist)))
+            ;; display-buffer-alist must not have duplicates: one
+            ;; COMMIT_EDITMSG entry and one magit-process entry.
+            (should (= 2 (length display-buffer-alist)))
             ;; Teardown must restore the real original
             (knayawp--teardown-magit-integration)
             (should (eq magit-display-buffer-function original)))
@@ -297,14 +303,21 @@
     (let ((original magit-display-buffer-function)
           (knayawp--magit-saved-display-fn nil)
           (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
           (knayawp-magit-commit-in-editor-flag t)
           (display-buffer-alist nil))
       (unwind-protect
           (progn
             (knayawp--setup-magit-integration)
-            (should (= 1 (length display-buffer-alist)))
-            (should (string-match-p "COMMIT_EDITMSG"
-                                    (caar display-buffer-alist)))
+            ;; Setup adds both the COMMIT_EDITMSG entry and the
+            ;; magit-process entry.
+            (should (= 2 (length display-buffer-alist)))
+            (should (seq-find
+                     (lambda (e)
+                       (and (stringp (car e))
+                            (string-match-p "COMMIT_EDITMSG"
+                                            (car e))))
+                     display-buffer-alist))
             (knayawp--teardown-magit-integration)
             (should (null display-buffer-alist)))
         (setq magit-display-buffer-function original)))))
@@ -315,13 +328,68 @@
     (let ((original magit-display-buffer-function)
           (knayawp--magit-saved-display-fn nil)
           (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
           (knayawp-magit-commit-in-editor-flag nil)
           (display-buffer-alist nil))
       (unwind-protect
           (progn
             (knayawp--setup-magit-integration)
-            (should (null display-buffer-alist))
-            (knayawp--teardown-magit-integration))
+            ;; Process entry is always added; commit entry only with flag.
+            (should (= 1 (length display-buffer-alist)))
+            (should-not (seq-find
+                         (lambda (e)
+                           (and (stringp (car e))
+                                (string-match-p "COMMIT_EDITMSG"
+                                                (car e))))
+                         display-buffer-alist))
+            (knayawp--teardown-magit-integration)
+            (should (null display-buffer-alist)))
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-magit-process-entry-initially-nil ()
+  "Process display-buffer-alist entry is nil before setup."
+  (should-not knayawp--process-display-entry))
+
+(ert-deftest knayawp-test-magit-process-buffer-p-no-window ()
+  "Process matcher returns nil when no magit side window exists.
+This guards against routing process buffers to a side window
+when no layout is active."
+  ;; In batch mode there are never side windows, so the matcher must
+  ;; return nil regardless of the candidate buffer's mode.
+  (let ((buf (get-buffer-create "*knayawp-test-process-buffer*")))
+    (unwind-protect
+        (should-not (knayawp--magit-process-buffer-p buf nil))
+      (kill-buffer buf))))
+
+(ert-deftest knayawp-test-magit-process-display-alist-entry ()
+  "Setup adds a `magit-process-mode' entry to `display-buffer-alist'.
+Teardown removes it."
+  (when (require 'magit nil t)
+    (let ((original magit-display-buffer-function)
+          (knayawp--magit-saved-display-fn nil)
+          (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
+          (knayawp-magit-commit-in-editor-flag nil)
+          (display-buffer-alist nil))
+      (unwind-protect
+          (progn
+            (knayawp--setup-magit-integration)
+            (should knayawp--process-display-entry)
+            (should (memq knayawp--process-display-entry
+                          display-buffer-alist))
+            ;; The matcher is our predicate function.
+            (should (eq 'knayawp--magit-process-buffer-p
+                        (car knayawp--process-display-entry)))
+            ;; The action routes to a right side window in the magit
+            ;; slot.
+            (let ((alist (cdr knayawp--process-display-entry)))
+              (should (memq 'display-buffer-in-side-window
+                            (car alist)))
+              (should (eq 'right (alist-get 'side alist)))
+              (should (equal -1 (alist-get 'slot alist))))
+            (knayawp--teardown-magit-integration)
+            (should-not knayawp--process-display-entry)
+            (should (null display-buffer-alist)))
         (setq magit-display-buffer-function original)))))
 
 ;;;; No project signals error


### PR DESCRIPTION
## Summary

- magit's `magit-process-display-buffer` calls `pop-to-buffer` directly, bypassing `magit-display-buffer-function`, so long-running git commands could pop the process buffer into the editor pane.
- Add a `display-buffer-alist` entry whose condition matches `magit-process-mode` buffers only while the knayawp magit side window exists in the selected frame, routing them to slot -1.
- Stays in the magit slot (rather than hidden) so push/fetch progress stays visible; magit's built-in `quit-restore` brings the previous magit buffer back on `q`.
- Entry is installed in `knayawp--setup-magit-integration` and removed in the teardown, mirroring the existing COMMIT_EDITMSG entry. Setup remains idempotent.
- 3 new ERT tests (initial state, no-window predicate guard, install/teardown alist shape). Existing magit-integration tests updated. 40/40 pass.

Closes #26 — the last open issue in milestone v0.1.2 (Magit Integration).

## Test plan

- [ ] `emacs -batch -f batch-byte-compile knayawp.el` — zero warnings
- [ ] `emacs -batch -l ert -l knayawp.el -l test/knayawp-test.el -f ert-run-tests-batch-and-exit` — 40/40 pass
- [ ] Live test: with layout active, run a slow git operation (`magit-fetch` or `magit-push`) and confirm the `*magit-process*` buffer appears in the magit slot rather than the editor pane.
- [ ] Without layout active, confirm `magit-process` falls through to magit's traditional display (no regression for non-knayawp users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)