### PR TITLE
feat: add knayawp-mode global minor mode

### DIFF
--- a/knayawp.el
+++ b/knayawp.el
@@ -565,5 +565,30 @@ Bind this to a prefix key of your choice, for example:
 
 (fset 'knayawp-command-map knayawp-command-map)
 
+;;;; Global minor mode
+
+(defun knayawp--mode-on ()
+  "Install global hooks and integration for `knayawp-mode'.
+Subsequent v0.1.3 work attaches behaviors here (project-switch
+auto-layout, `display-buffer-alist' routing).  No-op for now.")
+
+(defun knayawp--mode-off ()
+  "Tear down global hooks and integration for `knayawp-mode'.
+Inverse of `knayawp--mode-on'.  No-op for now.")
+
+;;;###autoload
+(define-minor-mode knayawp-mode
+  "Toggle knayawp global minor mode.
+When enabled, knayawp installs project-aware hooks and display
+routing that complement `knayawp-layout-setup'.  Loading the
+package alone never enables the mode (see property P7); the user
+must enable it explicitly."
+  :global t
+  :group 'knayawp
+  :lighter nil
+  (if knayawp-mode
+      (knayawp--mode-on)
+    (knayawp--mode-off)))
+
 (provide 'knayawp)
 ;;; knayawp.el ends here

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -137,6 +137,48 @@
   (should (not (equal '(nil nil nil 3)
                       (default-value 'window-sides-slots)))))
 
+(ert-deftest knayawp-test-mode-disabled-by-default ()
+  "`knayawp-mode' is disabled when the package is merely loaded."
+  (should (not (default-value 'knayawp-mode))))
+
+;;;; Global minor mode
+
+(ert-deftest knayawp-test-mode-defined ()
+  "`knayawp-mode' is a global minor mode."
+  (should (fboundp 'knayawp-mode))
+  (should (get 'knayawp-mode 'standard-value)))
+
+(ert-deftest knayawp-test-mode-toggle-invokes-helpers ()
+  "Enabling and disabling the mode calls the on/off helpers."
+  (let ((on-calls 0)
+        (off-calls 0))
+    (cl-letf (((symbol-function 'knayawp--mode-on)
+               (lambda () (cl-incf on-calls)))
+              ((symbol-function 'knayawp--mode-off)
+               (lambda () (cl-incf off-calls))))
+      (unwind-protect
+          (progn
+            (knayawp-mode 1)
+            (should (= 1 on-calls))
+            (should (= 0 off-calls))
+            (knayawp-mode -1)
+            (should (= 1 on-calls))
+            (should (= 1 off-calls)))
+        ;; Always leave the mode disabled.
+        (knayawp-mode -1)))))
+
+(ert-deftest knayawp-test-mode-roundtrip-leaves-disabled ()
+  "Toggling the mode on and off returns to the disabled state."
+  (cl-letf (((symbol-function 'knayawp--mode-on) #'ignore)
+            ((symbol-function 'knayawp--mode-off) #'ignore))
+    (unwind-protect
+        (progn
+          (knayawp-mode 1)
+          (should knayawp-mode)
+          (knayawp-mode -1)
+          (should (not knayawp-mode)))
+      (knayawp-mode -1))))
+
 ;;;; Command map
 
 (ert-deftest knayawp-test-command-map-exists ()


### PR DESCRIPTION
## Summary

- Define `knayawp-mode` as a `:global t` minor mode with autoload cookie.
- Stub `knayawp--mode-on` / `knayawp--mode-off` helpers — empty for now; subsequent v0.1.3 issues attach behaviors:
  - **#29** (auto-layout on `project-switch-project`) hooks into `knayawp--mode-on`.
  - **#33** (`display-buffer-alist` entries) hooks into `knayawp--mode-on`.
- P7 (passive loading) preserved: `(require 'knayawp)` does not enable the mode; the user must enable it explicitly.

The mode is intentionally inert in this PR. Splitting the mode shell from the hook implementations matches the milestone breakdown and keeps each PR focused.

## Tests

4 new ERT tests:
- `knayawp-test-mode-disabled-by-default` — P7 check on the mode itself.
- `knayawp-test-mode-defined` — mode is `fboundp`.
- `knayawp-test-mode-toggle-invokes-helpers` — `knayawp--mode-on/off` are called on toggle.
- `knayawp-test-mode-roundtrip-leaves-disabled` — toggle on/off returns to disabled.

44/44 pass. Byte-compile clean. Checkdoc clean.

Closes #28.

## Test plan

- [ ] `emacs -batch -f batch-byte-compile knayawp.el` — zero warnings
- [ ] `emacs -batch -l knayawp.el --eval '(checkdoc-file "knayawp.el")'` — clean
- [ ] `emacs -batch -l ert -l knayawp.el -l test/knayawp-test.el -f ert-run-tests-batch-and-exit` — 44/44 pass
- [ ] `M-x knayawp-mode` toggles cleanly in a live Emacs session

🤖 Generated with [Claude Code](https://claude.com/claude-code)