### PR TITLE
feat: auto-run knayawp-layout-setup on project-switch-project (#29)

### DIFF
--- a/knayawp.el
+++ b/knayawp.el
@@ -567,14 +567,30 @@ Bind this to a prefix key of your choice, for example:
 
 ;;;; Global minor mode
 
+(defvar knayawp--saved-project-switch-commands nil
+  "Saved value of `project-switch-commands' for restoration.
+Captured by `knayawp--mode-on' before installing the auto-layout
+action and restored by `knayawp--mode-off'.")
+
 (defun knayawp--mode-on ()
   "Install global hooks and integration for `knayawp-mode'.
-Subsequent v0.1.3 work attaches behaviors here (project-switch
-auto-layout, `display-buffer-alist' routing).  No-op for now.")
+Replace `project-switch-commands' with `knayawp-layout-setup' so
+that switching to a project via `project-switch-project'
+automatically sets up the knayawp layout.  The previous value is
+saved for restoration by `knayawp--mode-off'."
+  (unless (eq project-switch-commands #'knayawp-layout-setup)
+    (setq knayawp--saved-project-switch-commands
+          project-switch-commands))
+  (setq project-switch-commands #'knayawp-layout-setup))
 
 (defun knayawp--mode-off ()
   "Tear down global hooks and integration for `knayawp-mode'.
-Inverse of `knayawp--mode-on'.  No-op for now.")
+Inverse of `knayawp--mode-on': restore `project-switch-commands'
+to the value saved at mode activation."
+  (when (eq project-switch-commands #'knayawp-layout-setup)
+    (setq project-switch-commands
+          knayawp--saved-project-switch-commands))
+  (setq knayawp--saved-project-switch-commands nil))
 
 ;;;###autoload
 (define-minor-mode knayawp-mode

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -179,6 +179,54 @@
           (should (not knayawp-mode)))
       (knayawp-mode -1))))
 
+;;;; project-switch-project auto-layout (#29)
+
+(ert-deftest knayawp-test-mode-on-installs-project-switch-action ()
+  "Enabling the mode replaces `project-switch-commands'."
+  (let ((project-switch-commands 'sentinel-original)
+        (knayawp--saved-project-switch-commands nil))
+    (unwind-protect
+        (progn
+          (knayawp--mode-on)
+          (should (eq project-switch-commands
+                      #'knayawp-layout-setup))
+          (should (eq knayawp--saved-project-switch-commands
+                      'sentinel-original)))
+      (knayawp--mode-off))))
+
+(ert-deftest knayawp-test-mode-off-restores-project-switch-action ()
+  "Disabling the mode restores the saved `project-switch-commands'."
+  (let ((project-switch-commands 'sentinel-original)
+        (knayawp--saved-project-switch-commands nil))
+    (knayawp--mode-on)
+    (knayawp--mode-off)
+    (should (eq project-switch-commands 'sentinel-original))
+    (should-not knayawp--saved-project-switch-commands)))
+
+(ert-deftest knayawp-test-mode-on-double-call-preserves-saved ()
+  "Calling `knayawp--mode-on' twice keeps the original saved value."
+  (let ((project-switch-commands 'sentinel-original)
+        (knayawp--saved-project-switch-commands nil))
+    (unwind-protect
+        (progn
+          (knayawp--mode-on)
+          (knayawp--mode-on)
+          (should (eq knayawp--saved-project-switch-commands
+                      'sentinel-original))
+          (should (eq project-switch-commands
+                      #'knayawp-layout-setup)))
+      (knayawp--mode-off))))
+
+(ert-deftest knayawp-test-mode-off-no-op-when-not-installed ()
+  "Disabling the mode is safe when our action is not installed.
+This guards against clobbering a user value if mode-off is called
+without a matching mode-on."
+  (let ((project-switch-commands 'user-value)
+        (knayawp--saved-project-switch-commands nil))
+    (knayawp--mode-off)
+    (should (eq project-switch-commands 'user-value))
+    (should-not knayawp--saved-project-switch-commands)))
+
 ;;;; Command map
 
 (ert-deftest knayawp-test-command-map-exists ()


### PR DESCRIPTION
## Summary

- When `knayawp-mode` is enabled, `project-switch-commands` is replaced with `#'knayawp-layout-setup` so switching projects via `M-x project-switch-project` automatically sets up the knayawp layout (no post-switch menu prompt).
- The previous value of `project-switch-commands` is saved at mode-on and restored at mode-off; double mode-on preserves the original; mode-off without a matching mode-on is a no-op.
- Uses project.el's documented "skip the menu" extension point (function-as-value): no advice on built-ins → invariant **P2** preserved.

Closes #29

## Test plan

- [x] `emacs -batch -f batch-byte-compile knayawp.el` — zero warnings
- [x] `emacs -batch -l knayawp.el --eval '(checkdoc-file "knayawp.el")'` — clean
- [x] `emacs -batch -l ert -l knayawp.el -l test/knayawp-test.el -f ert-run-tests-batch-and-exit` — 48/48 pass (4 new for #29)
- [ ] Manual: enable `knayawp-mode`, run `M-x project-switch-project`, confirm layout sets up automatically in the new project
- [ ] Manual: disable `knayawp-mode`, confirm `project-switch-commands` returns to its prior value

🤖 Generated with [Claude Code](https://claude.com/claude-code)