### PR TITLE
feat: add knayawp-layout-hook for post-layout extension

### DIFF
--- a/knayawp.el
+++ b/knayawp.el
@@ -95,6 +95,15 @@ configuration is not yet exposed."
                                    :value-type integer))
   :group 'knayawp)
 
+(defcustom knayawp-layout-hook nil
+  "Hook run after `knayawp-layout-setup' creates the layout.
+Functions on this hook are called with no arguments, after all
+panels have been displayed and the editor window has been
+selected.  At that point the layout is fully constructed, so
+hook functions see the final window configuration."
+  :type 'hook
+  :group 'knayawp)
+
 ;;;; Internal state
 
 (defvar knayawp--active-layouts nil
@@ -385,7 +394,9 @@ left and is selected when done."
     ;; Install magit integration
     (knayawp--setup-magit-integration)
     ;; Select the main editor window
-    (knayawp--select-editor-window)))
+    (knayawp--select-editor-window)
+    ;; Run user hook last, so functions see the final state
+    (run-hooks 'knayawp-layout-hook)))
 
 (defun knayawp-layout-teardown ()
   "Remove the knayawp control pane from the current frame.

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -490,4 +490,23 @@ Teardown removes it."
     (should-error (knayawp--project-root)
                   :type 'user-error)))
 
+;;;; Layout hook (#31)
+
+(ert-deftest knayawp-test-layout-hook-defined ()
+  "`knayawp-layout-hook' is defined and defaults to nil."
+  (should (boundp 'knayawp-layout-hook))
+  (should (null (default-value 'knayawp-layout-hook))))
+
+(ert-deftest knayawp-test-layout-hook-not-run-on-error ()
+  "Hook does not run when `knayawp-layout-setup' errors early.
+When no project is found at `default-directory',
+`knayawp-layout-setup' must signal a user-error before reaching
+the end of its body, leaving `knayawp-layout-hook' unfired."
+  (let* ((counter 0)
+         (knayawp-layout-hook
+          (list (lambda () (cl-incf counter))))
+         (default-directory "/"))
+    (should-error (knayawp-layout-setup) :type 'user-error)
+    (should (= 0 counter))))
+
 ;;; knayawp-test.el ends here


### PR DESCRIPTION
## Summary

- Adds `knayawp-layout-hook`, a `defcustom` of type `'hook` (default `nil`) that fires at the end of `knayawp-layout-setup`, after the editor window is selected and the layout is fully constructed.
- Lets users plug in post-layout behaviour (winner-mode reset, custom buffer placement, project-specific tweaks) without modifying the package or wrapping the entry point in advice.
- Includes ERT coverage that the hook is defined with the right default and is *not* run when setup errors out before reaching the end of the body.

Closes #31

## Test plan

- [x] `emacs -batch -f batch-byte-compile knayawp.el` — zero warnings
- [x] `emacs -batch -l knayawp.el --eval '(checkdoc-file "knayawp.el")'` — clean
- [x] `emacs -batch -l ert -l knayawp.el -l test/knayawp-test.el -f ert-run-tests-batch-and-exit` — 50/50 pass