### PR TITLE
feat: route knayawp buffers via display-buffer-alist (mode-gated)

### DIFF
--- a/knayawp.el
+++ b/knayawp.el
@@ -115,6 +115,12 @@ Stored so it can be cleanly removed on teardown.")
   "The `display-buffer-alist' entry for `magit-process-mode' routing.
 Stored so it can be cleanly removed on teardown.")
 
+(defvar knayawp--panel-display-entries nil
+  "List of `display-buffer-alist' entries for knayawp panel buffers.
+Each entry routes buffers named `*knayawp-TYPE-*' to the side window
+slot configured for TYPE in `knayawp-panels'.  Stored so the entries
+can be removed precisely on `knayawp-mode' deactivation.")
+
 ;;;; Project detection
 
 (defun knayawp--project-root ()
@@ -565,6 +571,72 @@ Bind this to a prefix key of your choice, for example:
 
 (fset 'knayawp-command-map knayawp-command-map)
 
+;;;; Panel display routing
+
+(defun knayawp--panel-buffer-name-regexp (type)
+  "Return a regexp matching `*knayawp-TYPE-*' buffers for TYPE.
+TYPE is a panel-type symbol (for example `vterm' or `claude')."
+  (format "\\`\\*knayawp-%s-" (regexp-quote (symbol-name type))))
+
+(defun knayawp--make-panel-buffer-predicate (panel-spec)
+  "Return a `display-buffer-alist' predicate for PANEL-SPEC.
+The predicate takes (BUFFER-OR-NAME _ACTION) and returns non-nil
+only when BUFFER-OR-NAME matches the panel-type buffer-name pattern
+AND a knayawp side window for the panel's slot exists in the
+selected frame.  This gates the routing on layout presence so the
+entry is a no-op in unrelated frames."
+  (let ((regexp (knayawp--panel-buffer-name-regexp
+                 (knayawp--panel-type panel-spec)))
+        (slot (knayawp--panel-slot panel-spec)))
+    (lambda (buffer-or-name _action)
+      (let ((name (if (bufferp buffer-or-name)
+                      (buffer-name buffer-or-name)
+                    buffer-or-name)))
+        (and (stringp name)
+             (string-match-p regexp name)
+             (knayawp--side-window-for-slot slot))))))
+
+(defun knayawp--make-panel-display-entry (panel-spec)
+  "Build a `display-buffer-alist' entry for PANEL-SPEC.
+The entry's condition is a closure produced by
+`knayawp--make-panel-buffer-predicate'; the action routes the buffer
+to a right side window at the panel's slot."
+  (let ((slot (knayawp--panel-slot panel-spec)))
+    `(,(knayawp--make-panel-buffer-predicate panel-spec)
+      (display-buffer-reuse-window
+       display-buffer-in-side-window)
+      (side . right)
+      (slot . ,slot)
+      (window-width . ,knayawp-right-width)
+      (preserve-size . (t . nil))
+      (window-parameters
+       . ((no-delete-other-windows . t)
+          (no-other-window . t))))))
+
+(defun knayawp--install-panel-display-routing ()
+  "Install `display-buffer-alist' entries for knayawp panel buffers.
+For each panel in `knayawp-panels', push an entry that routes
+buffers named `*knayawp-TYPE-*' to the configured side-window slot
+when a knayawp side window exists in the selected frame.  The
+entries are recorded in `knayawp--panel-display-entries' so
+`knayawp--remove-panel-display-routing' can take them out cleanly.
+Idempotent: if entries are already installed, do nothing."
+  (unless knayawp--panel-display-entries
+    (let ((entries (mapcar #'knayawp--make-panel-display-entry
+                           knayawp-panels)))
+      (setq knayawp--panel-display-entries entries)
+      (dolist (entry entries)
+        (push entry display-buffer-alist)))))
+
+(defun knayawp--remove-panel-display-routing ()
+  "Remove panel buffer routing from `display-buffer-alist'.
+Inverse of `knayawp--install-panel-display-routing': drop each
+recorded entry from `display-buffer-alist' and clear
+`knayawp--panel-display-entries'."
+  (dolist (entry knayawp--panel-display-entries)
+    (setq display-buffer-alist (delq entry display-buffer-alist)))
+  (setq knayawp--panel-display-entries nil))
+
 ;;;; Global minor mode
 
 (defvar knayawp--saved-project-switch-commands nil
@@ -577,20 +649,25 @@ action and restored by `knayawp--mode-off'.")
 Replace `project-switch-commands' with `knayawp-layout-setup' so
 that switching to a project via `project-switch-project'
 automatically sets up the knayawp layout.  The previous value is
-saved for restoration by `knayawp--mode-off'."
+saved for restoration by `knayawp--mode-off'.  Also install the
+`display-buffer-alist' entries that route `*knayawp-TYPE-PROJECT*'
+buffers to their configured side-window slots."
   (unless (eq project-switch-commands #'knayawp-layout-setup)
     (setq knayawp--saved-project-switch-commands
           project-switch-commands))
-  (setq project-switch-commands #'knayawp-layout-setup))
+  (setq project-switch-commands #'knayawp-layout-setup)
+  (knayawp--install-panel-display-routing))
 
 (defun knayawp--mode-off ()
   "Tear down global hooks and integration for `knayawp-mode'.
 Inverse of `knayawp--mode-on': restore `project-switch-commands'
-to the value saved at mode activation."
+to the value saved at mode activation and remove the panel buffer
+`display-buffer-alist' entries."
   (when (eq project-switch-commands #'knayawp-layout-setup)
     (setq project-switch-commands
           knayawp--saved-project-switch-commands))
-  (setq knayawp--saved-project-switch-commands nil))
+  (setq knayawp--saved-project-switch-commands nil)
+  (knayawp--remove-panel-display-routing))
 
 ;;;###autoload
 (define-minor-mode knayawp-mode

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -482,6 +482,149 @@ Teardown removes it."
             (should (null display-buffer-alist)))
         (setq magit-display-buffer-function original)))))
 
+;;;; Panel display routing (#33)
+
+(ert-deftest knayawp-test-panel-display-entries-initially-nil ()
+  "Panel display entries are nil before installation."
+  (should-not knayawp--panel-display-entries))
+
+(ert-deftest knayawp-test-panel-buffer-name-regexp ()
+  "Predicate regexp matches `*knayawp-TYPE-*' buffers only."
+  (let ((re (knayawp--panel-buffer-name-regexp 'vterm)))
+    (should (string-match-p re "*knayawp-vterm-foo*"))
+    (should (string-match-p re "*knayawp-vterm-my-app*"))
+    (should-not (string-match-p re "*knayawp-claude-foo*"))
+    (should-not (string-match-p re "*scratch*"))
+    (should-not (string-match-p re "vterm-foo"))))
+
+(ert-deftest knayawp-test-panel-buffer-predicate-no-window ()
+  "Predicate returns nil when no knayawp side window exists.
+In batch mode there are never side windows, so the predicate must
+return nil regardless of the buffer name match."
+  (let* ((spec '(vterm :slot 0))
+         (pred (knayawp--make-panel-buffer-predicate spec))
+         (buf (get-buffer-create "*knayawp-vterm-testproj*")))
+    (unwind-protect
+        (progn
+          (should-not (funcall pred buf nil))
+          (should-not (funcall pred "*knayawp-vterm-testproj*" nil)))
+      (kill-buffer buf))))
+
+(ert-deftest knayawp-test-panel-buffer-predicate-rejects-non-match ()
+  "Predicate rejects buffers that do not match the type pattern."
+  (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+             (lambda (_slot) 'fake-window)))
+    (let* ((spec '(vterm :slot 0))
+           (pred (knayawp--make-panel-buffer-predicate spec)))
+      ;; Even with a "side window" present, name mismatch returns nil.
+      (should-not (funcall pred "*scratch*" nil))
+      (should-not (funcall pred "*knayawp-claude-foo*" nil))
+      ;; Matching name with side window present returns truthy.
+      (should (funcall pred "*knayawp-vterm-foo*" nil)))))
+
+(ert-deftest knayawp-test-install-panel-display-routing-adds-entries ()
+  "Install adds one entry per panel to `display-buffer-alist'."
+  (let ((display-buffer-alist nil)
+        (knayawp--panel-display-entries nil)
+        (knayawp-panels '((magit  :slot -1)
+                          (vterm  :slot  0)
+                          (claude :slot  1))))
+    (unwind-protect
+        (progn
+          (knayawp--install-panel-display-routing)
+          (should (= 3 (length knayawp--panel-display-entries)))
+          (dolist (entry knayawp--panel-display-entries)
+            (should (memq entry display-buffer-alist))
+            (should (functionp (car entry)))))
+      (knayawp--remove-panel-display-routing))))
+
+(ert-deftest knayawp-test-remove-panel-display-routing-clears-entries ()
+  "Remove takes installed entries out of `display-buffer-alist'."
+  (let ((display-buffer-alist nil)
+        (knayawp--panel-display-entries nil)
+        (knayawp-panels '((magit  :slot -1)
+                          (vterm  :slot  0)
+                          (claude :slot  1))))
+    (knayawp--install-panel-display-routing)
+    (knayawp--remove-panel-display-routing)
+    (should (null knayawp--panel-display-entries))
+    (should (null display-buffer-alist))))
+
+(ert-deftest knayawp-test-panel-display-routing-roundtrip ()
+  "Round-trip leaves `display-buffer-alist' unchanged."
+  (let* ((sentinel '("sentinel" display-buffer-pop-up-window))
+         (display-buffer-alist (list sentinel))
+         (before (copy-sequence display-buffer-alist))
+         (knayawp--panel-display-entries nil)
+         (knayawp-panels '((magit  :slot -1)
+                           (vterm  :slot  0)
+                           (claude :slot  1))))
+    (knayawp--install-panel-display-routing)
+    (knayawp--remove-panel-display-routing)
+    (should (equal before display-buffer-alist))))
+
+(ert-deftest knayawp-test-install-panel-display-routing-idempotent ()
+  "Double install does not duplicate entries."
+  (let ((display-buffer-alist nil)
+        (knayawp--panel-display-entries nil)
+        (knayawp-panels '((magit  :slot -1)
+                          (vterm  :slot  0)
+                          (claude :slot  1))))
+    (unwind-protect
+        (progn
+          (knayawp--install-panel-display-routing)
+          (knayawp--install-panel-display-routing)
+          (should (= 3 (length knayawp--panel-display-entries)))
+          (should (= 3 (length display-buffer-alist))))
+      (knayawp--remove-panel-display-routing))))
+
+(ert-deftest knayawp-test-mode-on-installs-panel-routing ()
+  "Enabling `knayawp-mode' installs panel display entries."
+  (let ((display-buffer-alist nil)
+        (project-switch-commands 'sentinel-original)
+        (knayawp--saved-project-switch-commands nil)
+        (knayawp--panel-display-entries nil)
+        (knayawp-panels '((magit  :slot -1)
+                          (vterm  :slot  0)
+                          (claude :slot  1))))
+    (unwind-protect
+        (progn
+          (knayawp--mode-on)
+          (should (= 3 (length knayawp--panel-display-entries)))
+          (should (= 3 (length display-buffer-alist))))
+      (knayawp--mode-off))))
+
+(ert-deftest knayawp-test-mode-off-removes-panel-routing ()
+  "Disabling `knayawp-mode' removes panel display entries."
+  (let ((display-buffer-alist nil)
+        (project-switch-commands 'sentinel-original)
+        (knayawp--saved-project-switch-commands nil)
+        (knayawp--panel-display-entries nil)
+        (knayawp-panels '((magit  :slot -1)
+                          (vterm  :slot  0)
+                          (claude :slot  1))))
+    (knayawp--mode-on)
+    (knayawp--mode-off)
+    (should (null knayawp--panel-display-entries))
+    (should (null display-buffer-alist))))
+
+(ert-deftest knayawp-test-mode-double-on-does-not-duplicate-routing ()
+  "Calling `knayawp--mode-on' twice does not duplicate entries."
+  (let ((display-buffer-alist nil)
+        (project-switch-commands 'sentinel-original)
+        (knayawp--saved-project-switch-commands nil)
+        (knayawp--panel-display-entries nil)
+        (knayawp-panels '((magit  :slot -1)
+                          (vterm  :slot  0)
+                          (claude :slot  1))))
+    (unwind-protect
+        (progn
+          (knayawp--mode-on)
+          (knayawp--mode-on)
+          (should (= 3 (length knayawp--panel-display-entries)))
+          (should (= 3 (length display-buffer-alist))))
+      (knayawp--mode-off))))
+
 ;;;; No project signals error
 
 (ert-deftest knayawp-test-no-project-error ()


### PR DESCRIPTION
## Summary

- Install three `display-buffer-alist` entries on `knayawp-mode` activation, one per panel in `knayawp-panels`. Each pairs a predicate closure that matches `*knayawp-TYPE-*` AND requires a knayawp side window at the panel's slot in the selected frame, with an action that re-uses `display-buffer-in-side-window` at that slot.
- `M-x switch-to-buffer *knayawp-vterm-foo*` (or any other entry path) now lands in the configured slot instead of an arbitrary editor window. The side-window gate keeps the routing a no-op when no layout is active in the current frame.
- Entries are recorded in `knayawp--panel-display-entries` so teardown can `delq` them precisely, mirroring the existing `magit-process-mode` routing pattern.

## Lifecycle

Install on `knayawp--mode-on`, uninstall on `knayawp--mode-off` -- the same place the project-switch hook lives. Property P7 (passive loading) is preserved: merely loading the package still adds nothing to `display-buffer-alist`. Users get a single switch (`M-x knayawp-mode`) for both behaviors.

Closes #33

## Test plan

- [x] `emacs -batch -f batch-byte-compile knayawp.el` -- zero warnings
- [x] `emacs -batch -l knayawp.el --eval '(checkdoc-file "knayawp.el")'` -- silent
- [x] `emacs -batch -l ert -l knayawp.el -l test/knayawp-test.el -f ert-run-tests-batch-and-exit` -- 59 / 59 passing (11 new tests cover predicate gating, install/remove round-trip, idempotency, mode-on/off integration)