### PR TITLE
feat: add knayawp-keymap-style with tmux and byobu presets

### DIFF
--- a/knayawp.el
+++ b/knayawp.el
@@ -81,6 +81,34 @@ behavior."
   :type 'boolean
   :group 'knayawp)
 
+(defcustom knayawp-keymap-style 'default
+  "Keybinding style for the variable `knayawp-command-map'.
+The same set of commands is bound under every style; only the
+keys differ.
+
+`default' uses numbered keys (1/2/3) and n/p for panel
+navigation.  This is the historical layout and the safest choice
+for users on terminals without arrow-key support.
+
+`tmux' adds arrow-key navigation inspired by tmux pane bindings:
+<up>/<down> select the previous/next panel within the control
+pane, while <left>/<right> are reserved for previous/next project
+tab (wired in v0.2).  All numbered and letter keys remain bound
+as a fallback.
+
+`byobu' adds shift-arrow navigation inspired by byobu's
+Shift-Function-arrow window bindings: S-<up>/S-<down> select the
+previous/next panel and S-<left>/S-<right> are reserved for
+previous/next project tab (wired in v0.2).  All numbered and
+letter keys remain bound as a fallback.
+
+Changing this value at runtime does not rebuild the keymap
+automatically; call `knayawp-rebuild-command-map' afterwards."
+  :type '(choice (const :tag "Default (1/2/3, n/p)" default)
+                 (const :tag "tmux (arrow keys)" tmux)
+                 (const :tag "byobu (shift-arrow keys)" byobu))
+  :group 'knayawp)
+
 (defcustom knayawp-panels
   '((magit  :slot -1)
     (vterm  :slot  0)
@@ -546,24 +574,91 @@ a side window."
 
 ;;;; Command map
 
-(defvar knayawp-command-map
+(defun knayawp--select-panel-1 ()
+  "Select panel 1 in the control pane."
+  (interactive)
+  (knayawp-select-panel 1))
+
+(defun knayawp--select-panel-2 ()
+  "Select panel 2 in the control pane."
+  (interactive)
+  (knayawp-select-panel 2))
+
+(defun knayawp--select-panel-3 ()
+  "Select panel 3 in the control pane."
+  (interactive)
+  (knayawp-select-panel 3))
+
+(defun knayawp--bind-common-keys (map)
+  "Install the style-independent letter and digit bindings on MAP.
+These bindings are shared by every value of `knayawp-keymap-style'
+so that layout management, direct panel selection, zoom, editor
+return, and toggle-panels are always reachable without an arrow
+key."
+  (define-key map "l" #'knayawp-layout-setup)
+  (define-key map "q" #'knayawp-layout-teardown)
+  (define-key map "1" #'knayawp--select-panel-1)
+  (define-key map "2" #'knayawp--select-panel-2)
+  (define-key map "3" #'knayawp--select-panel-3)
+  (define-key map "n" #'knayawp-next-panel)
+  (define-key map "p" #'knayawp-prev-panel)
+  (define-key map "z" #'knayawp-zoom-panel)
+  (define-key map "0" #'knayawp-select-editor)
+  (define-key map "s" #'knayawp-toggle-panels)
+  map)
+
+(defun knayawp--build-command-map ()
+  "Return a fresh sparse keymap configured for `knayawp-keymap-style'.
+Every style binds the full command surface (layout setup and
+teardown, direct panel selection, next/previous panel, zoom,
+select-editor, toggle-panels).  Only the keys differ between
+styles.  See `knayawp-keymap-style' for the per-style layout."
   (let ((map (make-sparse-keymap)))
-    (define-key map "l" #'knayawp-layout-setup)
-    (define-key map "q" #'knayawp-layout-teardown)
-    (define-key map "1" (lambda () (interactive) (knayawp-select-panel 1)))
-    (define-key map "2" (lambda () (interactive) (knayawp-select-panel 2)))
-    (define-key map "3" (lambda () (interactive) (knayawp-select-panel 3)))
-    (define-key map "n" #'knayawp-next-panel)
-    (define-key map "p" #'knayawp-prev-panel)
-    (define-key map "z" #'knayawp-zoom-panel)
-    (define-key map "0" #'knayawp-select-editor)
-    (define-key map "s" #'knayawp-toggle-panels)
-    map)
+    (knayawp--bind-common-keys map)
+    (pcase knayawp-keymap-style
+      ('default map)
+      ('tmux
+       ;; tmux pane navigation: <up>/<down> step through panels.
+       ;; <left>/<right> are reserved for project-tab navigation
+       ;; (wired in v0.2); leave them unbound for now so the user
+       ;; gets a clear "key not bound" hint instead of a surprise.
+       (define-key map (kbd "<up>")   #'knayawp-prev-panel)
+       (define-key map (kbd "<down>") #'knayawp-next-panel)
+       map)
+      ('byobu
+       ;; byobu Shift-Function-arrow style: S-<up>/S-<down> step
+       ;; through panels.  S-<left>/S-<right> reserved for project
+       ;; tabs (v0.2).
+       (define-key map (kbd "S-<up>")   #'knayawp-prev-panel)
+       (define-key map (kbd "S-<down>") #'knayawp-next-panel)
+       map)
+      (_ (user-error "Unknown knayawp-keymap-style: %s"
+                     knayawp-keymap-style)))))
+
+(defvar knayawp-command-map (knayawp--build-command-map)
   "Keymap for knayawp commands.
 Bind this to a prefix key of your choice, for example:
-  (global-set-key (kbd \"C-c k\") knayawp-command-map)")
+  (global-set-key (kbd \"C-c k\") knayawp-command-map)
+The concrete key layout depends on `knayawp-keymap-style'.  After
+changing that option, call `knayawp-rebuild-command-map' to apply
+the new style without restarting Emacs.")
 
 (fset 'knayawp-command-map knayawp-command-map)
+
+;;;###autoload
+(defun knayawp-rebuild-command-map ()
+  "Rebuild the variable `knayawp-command-map' from `knayawp-keymap-style'.
+Call this after changing `knayawp-keymap-style' at runtime.  The
+underlying keymap object is mutated in place so existing prefix
+bindings (e.g. `C-c k') keep working without rebinding."
+  (interactive)
+  (let ((fresh (knayawp--build-command-map)))
+    ;; Mutate the existing keymap object in place so any prefix
+    ;; binding the user installed continues to resolve.
+    (setcdr knayawp-command-map (cdr fresh)))
+  (fset 'knayawp-command-map knayawp-command-map)
+  (message "knayawp: rebuilt command map for %s style"
+           knayawp-keymap-style))
 
 ;;;; Global minor mode
 

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -249,10 +249,81 @@ without a matching mode-on."
               (lookup-key knayawp-command-map "0")))
   (should (eq 'knayawp-toggle-panels
               (lookup-key knayawp-command-map "s")))
-  ;; 1/2/3 are lambdas, just verify they're bound
-  (should (lookup-key knayawp-command-map "1"))
-  (should (lookup-key knayawp-command-map "2"))
-  (should (lookup-key knayawp-command-map "3")))
+  ;; 1/2/3 dispatch directly through named helpers
+  (should (eq 'knayawp--select-panel-1
+              (lookup-key knayawp-command-map "1")))
+  (should (eq 'knayawp--select-panel-2
+              (lookup-key knayawp-command-map "2")))
+  (should (eq 'knayawp--select-panel-3
+              (lookup-key knayawp-command-map "3"))))
+
+;;;; Keymap style
+
+(ert-deftest knayawp-test-keymap-style-default-value ()
+  "`knayawp-keymap-style' defaults to `default'."
+  (should (eq 'default (default-value 'knayawp-keymap-style))))
+
+(ert-deftest knayawp-test-build-default-style-no-arrows ()
+  "Default style does not bind <up>, <down>, S-<up>, or S-<down>."
+  (let* ((knayawp-keymap-style 'default)
+         (map (knayawp--build-command-map)))
+    (should (eq 'knayawp-next-panel (lookup-key map "n")))
+    (should (eq 'knayawp-prev-panel (lookup-key map "p")))
+    (should-not (lookup-key map (kbd "<up>")))
+    (should-not (lookup-key map (kbd "<down>")))
+    (should-not (lookup-key map (kbd "S-<up>")))
+    (should-not (lookup-key map (kbd "S-<down>")))))
+
+(ert-deftest knayawp-test-build-tmux-style-arrow-bindings ()
+  "Tmux style binds <up>/<down> to panel navigation."
+  (let* ((knayawp-keymap-style 'tmux)
+         (map (knayawp--build-command-map)))
+    (should (eq 'knayawp-prev-panel (lookup-key map (kbd "<up>"))))
+    (should (eq 'knayawp-next-panel (lookup-key map (kbd "<down>"))))
+    ;; Letter fallback still works.
+    (should (eq 'knayawp-layout-setup (lookup-key map "l")))
+    (should (eq 'knayawp-next-panel (lookup-key map "n")))
+    ;; <left>/<right> are reserved for v0.2 project tabs and unbound now.
+    (should-not (lookup-key map (kbd "<left>")))
+    (should-not (lookup-key map (kbd "<right>")))))
+
+(ert-deftest knayawp-test-build-byobu-style-shift-arrow-bindings ()
+  "Byobu style binds S-<up>/S-<down> to panel navigation."
+  (let* ((knayawp-keymap-style 'byobu)
+         (map (knayawp--build-command-map)))
+    (should (eq 'knayawp-prev-panel (lookup-key map (kbd "S-<up>"))))
+    (should (eq 'knayawp-next-panel (lookup-key map (kbd "S-<down>"))))
+    ;; Letter fallback still works.
+    (should (eq 'knayawp-zoom-panel (lookup-key map "z")))
+    (should (eq 'knayawp-toggle-panels (lookup-key map "s")))
+    ;; S-<left>/S-<right> are reserved for v0.2 and unbound now.
+    (should-not (lookup-key map (kbd "S-<left>")))
+    (should-not (lookup-key map (kbd "S-<right>")))))
+
+(ert-deftest knayawp-test-build-unknown-style-errors ()
+  "Building the keymap with an unknown style signals user-error."
+  (let ((knayawp-keymap-style 'banana))
+    (should-error (knayawp--build-command-map) :type 'user-error)))
+
+(ert-deftest knayawp-test-rebuild-command-map-mutates-in-place ()
+  "`knayawp-rebuild-command-map' mutates the existing keymap object.
+This preserves any prefix binding the user installed against
+`knayawp-command-map'."
+  (let ((original-object knayawp-command-map)
+        (knayawp-keymap-style 'tmux))
+    (unwind-protect
+        (progn
+          (knayawp-rebuild-command-map)
+          ;; Same keymap object — prefix bindings still work.
+          (should (eq original-object knayawp-command-map))
+          ;; New style took effect.
+          (should (eq 'knayawp-prev-panel
+                      (lookup-key knayawp-command-map (kbd "<up>"))))
+          (should (eq 'knayawp-next-panel
+                      (lookup-key knayawp-command-map (kbd "<down>")))))
+      ;; Restore default style for subsequent tests.
+      (setq knayawp-keymap-style 'default)
+      (knayawp-rebuild-command-map))))
 
 ;;;; Buffer reuse
 


### PR DESCRIPTION
Closes #22

## Summary

Introduce `knayawp-keymap-style` (default `'default`) — a defcustom that selects the keybinding layout for `knayawp-command-map`. Three presets are supported; every style binds the same set of commands, only the keys differ.

### Default style (unchanged)

| Key | Command |
|-----|---------|
| `l` | `knayawp-layout-setup` |
| `q` | `knayawp-layout-teardown` |
| `1`/`2`/`3` | direct panel select |
| `n`/`p` | next/prev panel |
| `z` | zoom panel |
| `0` | select editor |
| `s` | toggle panels |

### tmux style

Adds arrow-key panel navigation. All default keys remain bound as a fallback (per the issue body's "Numbered keys still available" note).

| Key | Command |
|-----|---------|
| `<up>` | `knayawp-prev-panel` |
| `<down>` | `knayawp-next-panel` |
| `<left>` / `<right>` | reserved for v0.2 project-tab navigation (unbound today) |
| `n` / `b` | reserved for v0.2 project-tab navigation; `n` continues to mean next-panel as fallback until v0.2 lands |

### byobu style

Adds shift-arrow panel navigation, inspired by byobu's Shift-Function-arrow window bindings. All default keys remain bound as a fallback.

| Key | Command |
|-----|---------|
| `S-<up>` | `knayawp-prev-panel` |
| `S-<down>` | `knayawp-next-panel` |
| `S-<left>` / `S-<right>` | reserved for v0.2 project-tab navigation (unbound today) |

### Runtime style switching

A new interactive `knayawp-rebuild-command-map` rebuilds the command map from the current style and mutates the existing keymap object in place, so any prefix binding the user installed (e.g. `C-c k`) keeps resolving without a rebind.

### Decision: why byobu uses shift-arrows, not F-keys

Byobu's real defaults rely on F-keys (`F2` new, `F3`/`F4` prev/next window, Shift variants for screens). F-keys are commonly rebound by users and clash with mode-specific bindings, so the byobu preset borrows the shift-arrow direction half of byobu's vocabulary instead. The intent — modifier+arrow window navigation — matches byobu faithfully without grabbing F-keys.

## Test plan

- [x] `emacs -batch -f batch-byte-compile knayawp.el` — zero warnings
- [x] `emacs -batch -l knayawp.el --eval '(checkdoc-file "knayawp.el")'` — zero warnings
- [x] `emacs -batch -l ert -l knayawp.el -l test/knayawp-test.el -f ert-run-tests-batch-and-exit` — 54/54 pass (was 48; +6 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)