### PR TITLE
feat: zoom-based commit flow (#48 + #53)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -190,11 +190,11 @@ Resolved design decisions:
 - [ ] winner-mode integration — save/restore via winner before tearing down — #32
 - [ ] Make right-pane slot heights configurable — #56
 - [ ] Handle edge cases: frame too narrow (skip right panels), missing magit/vterm — #30
-- [ ] Magit transient buffers escape side window containment during commit — #48
+- [x] Magit transient buffers escape side window containment during commit — #48
 - [x] C-x o cycles into side windows despite no-other-window parameter — #49
 - [x] Side pane width not preserved after frame resize — #50
 - [ ] Managed transient splits in editor pane for side-pane-triggered visits — #52
-- [ ] Commit flow: focus should land on COMMIT_EDITMSG, not diff — #53
+- [x] Commit flow: focus should land on COMMIT_EDITMSG, not diff — #53
 - [ ] `knayawp--mode-off` can clobber user-set `project-switch-commands` — #60
 - [ ] Add `kb/` entry for `knayawp-mode` project-switch integration — #61
 - [ ] Re-install display-buffer-alist routing when knayawp-panels changes — #65

--- a/kb/properties.md
+++ b/kb/properties.md
@@ -66,8 +66,12 @@ Simply loading (`require`) the package must not activate any functionality. No h
 - If the selected terminal backend is not installed: signal a `user-error` with a clear message naming the missing package.
 - If the frame is too narrow for the layout: skip the control pane and message the user.
 
-## P9: with-editor Cooperation
+## P9: with-editor Cooperation via Self-Managed Winconf
 
-knayawp's commit flow must not save or restore window configurations itself. The `with-editor` package's `with-editor-previous-winconf` mechanism is the source of truth for pre/post-commit layout. knayawp participates by zooming at `git-commit-setup-hook` and by setting focus on `with-editor-post-finish-hook` / `with-editor-post-cancel-hook`; it never calls `set-window-configuration`.
+When the `'zoom` commit style is active, knayawp captures `(current-window-configuration)` in `knayawp--commit-flow-start` *before* mutating the layout (i.e. before `knayawp--apply-zoom-solo-magit` runs). On commit finish or cancel, `knayawp--restore-commit-pre-state` calls `set-window-configuration` on that captured snapshot, overriding the restore that `with-editor` performs from its own `with-editor-previous-winconf`. with-editor's snapshot is captured *after* knayawp's `git-commit-setup-hook` handler has already zoomed, so it only contains the magit slot — restoring from it would lose the terminal and Claude side windows. knayawp's own snapshot, taken pre-zoom, is the only reliable source for the full 3-panel layout.
 
-P5's "no custom restoration code" clause applies to `q`-quit of magit transients within a single side window slot. The commit lifecycle is a distinct multi-buffer flow whose layout restoration is handled by `with-editor`'s built-in `with-editor-previous-winconf` mechanism, and the two properties do not conflict.
+knayawp does not advise or rebind any with-editor function. It cooperates through documented extension points: `git-commit-setup-hook` to enter the zoom, and `with-editor-post-finish-hook` / `with-editor-post-cancel-hook` to drive the restore. with-editor's own `set-window-configuration` call runs first and is intentionally overwritten by ours.
+
+**Why:** Running our restore after with-editor's restore (rather than instead of it) avoids touching with-editor internals while still producing the right post-commit layout. The restore is gated on `(eq (window-configuration-frame winconf) (selected-frame))` to avoid cross-frame scrambling.
+
+P5's "no custom restoration code" clause applies to `q`-quit of magit transients within a single side window slot. The commit lifecycle is a distinct multi-buffer flow that legitimately requires knayawp-managed restoration, and the two properties do not conflict.

--- a/kb/properties.md
+++ b/kb/properties.md
@@ -1,6 +1,6 @@
 ---
 title: knayawp.el Invariants and Properties
-last-updated: 2026-04-27
+last-updated: 2026-06-09
 status: draft
 ---
 
@@ -75,3 +75,15 @@ knayawp does not advise or rebind any with-editor function. It cooperates throug
 **Why:** Running our restore after with-editor's restore (rather than instead of it) avoids touching with-editor internals while still producing the right post-commit layout. The restore is gated on `(eq (window-configuration-frame winconf) (selected-frame))` to avoid cross-frame scrambling.
 
 P5's "no custom restoration code" clause applies to `q`-quit of magit transients within a single side window slot. The commit lifecycle is a distinct multi-buffer flow that legitimately requires knayawp-managed restoration, and the two properties do not conflict.
+
+## P10: Commit-Style State Reconciliation
+
+Whenever the magit integration is installed (`magit-display-buffer-function` is `knayawp--magit-display-buffer`), the set of installed commit-flow hooks and the presence of the `COMMIT_EDITMSG` `display-buffer-alist` entry must match the *currently resolved* value of `knayawp-magit-commit-style`. That is:
+
+- Resolved `'zoom`  → commit-flow hooks installed, COMMIT_EDITMSG entry absent.
+- Resolved `'editor` → COMMIT_EDITMSG entry installed, commit-flow hooks absent.
+- Resolved `'off`   → both absent.
+
+The reconcile is driven by `knayawp--reconcile-commit-style`, which both `knayawp--setup-magit-integration` and the `:set` form of `knayawp-magit-commit-style` call. Setting the option via `customize-set-variable` or `setopt` triggers an immediate reconcile when the integration is active; setting via plain `setq` does not (standard Emacs `defcustom` semantics) and is recovered by the next `knayawp-layout-setup` call, which always reconciles.
+
+**Why:** Without this invariant, switching styles at runtime leaves stale install bits behind — for example, the zoom commit-flow hooks remain installed after a switch to `'editor`, intercepting the next commit and routing COMMIT_EDITMSG into the magit slot instead of the editor pane. The scenario-2 probe in PR #76 caught this defect; the reconcile design replaces the previous install-only setup path.

--- a/kb/properties.md
+++ b/kb/properties.md
@@ -65,3 +65,9 @@ Simply loading (`require`) the package must not activate any functionality. No h
 - If magit is not installed: the magit panel shows an informational buffer, not an error.
 - If the selected terminal backend is not installed: signal a `user-error` with a clear message naming the missing package.
 - If the frame is too narrow for the layout: skip the control pane and message the user.
+
+## P9: with-editor Cooperation
+
+knayawp's commit flow must not save or restore window configurations itself. The `with-editor` package's `with-editor-previous-winconf` mechanism is the source of truth for pre/post-commit layout. knayawp participates by zooming at `git-commit-setup-hook` and by setting focus on `with-editor-post-finish-hook` / `with-editor-post-cancel-hook`; it never calls `set-window-configuration`.
+
+P5's "no custom restoration code" clause applies to `q`-quit of magit transients within a single side window slot. The commit lifecycle is a distinct multi-buffer flow whose layout restoration is handled by `with-editor`'s built-in `with-editor-previous-winconf` mechanism, and the two properties do not conflict.

--- a/kb/spec.md
+++ b/kb/spec.md
@@ -54,6 +54,22 @@ Long-term Emacs users (not necessarily "power users") who:
 - Pressing `q` restores the previous magit buffer (built-in `quit-restore`)
 - COMMIT_EDITMSG opens in the editor pane (commits are editing tasks)
 
+**Commit flow:**
+
+When the user initiates a commit (e.g. `c c` in magit-status), the
+magit side window expands ("zooms") to fill the right column and the
+COMMIT_EDITMSG buffer is displayed within it. On commit finish or
+cancel, the 3-panel layout is restored automatically.
+
+This behavior is controlled by `knayawp-magit-commit-style` (default
+`'zoom`). Setting the style to `'editor` reverts to the v0.1.3
+behavior of routing COMMIT_EDITMSG to the editor pane while the diff
+goes to the magit slot. Setting it to `'off` disables all special
+commit handling.
+
+After a commit completes, focus returns to the editor pane (configurable
+via `knayawp-magit-commit-focus-after`).
+
 **Terminal backend:**
 - Pluggable: vterm (default) or eat, selected via customization variable
 - All terminal creation goes through a dispatch layer — no direct vterm/eat API calls outside it

--- a/knayawp.el
+++ b/knayawp.el
@@ -113,9 +113,14 @@ Useful for users with their own magit display function.
 
 Changing this value at runtime affects future commit sessions
 only; an in-progress commit completes under the style it was
-started with.  Run \\[knayawp-layout-setup] (or tear down and
-re-create the layout) to install or remove the relevant hooks
-after a change.
+started with.  When the magit integration is currently active
+\(i.e. a knayawp layout has been set up), setting this option via
+\\[customize-option], `setopt', or `customize-set-variable'
+triggers an immediate reconcile: hooks and `display-buffer-alist'
+entries from the previous style are removed and those for the
+new style are installed.  Plain `setq' bypasses the `:set' form
+\(standard Emacs behavior); after a `setq', call
+\\[knayawp-layout-setup] to apply the new style.
 
 The `zoom' value requires `knayawp-layout-setup' to have been
 called: zoom is a no-op without an active layout.  The other two
@@ -124,6 +129,18 @@ values are also no-ops without the layout."
                  (const :tag "Pop COMMIT_EDITMSG to editor pane" editor)
                  (const :tag "Default magit display (no special handling)"
                         off))
+  :set (lambda (sym val)
+         (set-default sym val)
+         ;; Reconcile commit-style state only when the magit
+         ;; integration is currently installed; otherwise the new
+         ;; value is picked up by the next `knayawp-layout-setup'.
+         ;; `fboundp' guard tolerates a `setopt' issued before
+         ;; the rest of the file has finished loading.
+         (when (and (fboundp 'knayawp--reconcile-commit-style)
+                    (boundp 'magit-display-buffer-function)
+                    (eq magit-display-buffer-function
+                        #'knayawp--magit-display-buffer))
+           (knayawp--reconcile-commit-style)))
   :group 'knayawp)
 
 (defcustom knayawp-magit-commit-focus-after 'editor
@@ -747,16 +764,58 @@ Inverse of `knayawp--install-commit-hooks'.  Idempotent."
                  #'knayawp--server-switch-handler)
     (setq knayawp--commit-hooks-installed nil)))
 
+(defun knayawp--install-commit-display-entry ()
+  "Install the COMMIT_EDITMSG `display-buffer-alist' entry.
+Idempotent: if the entry is already in place, do nothing."
+  (unless knayawp--commit-display-entry
+    (setq knayawp--commit-display-entry
+          '("COMMIT_EDITMSG"
+            (display-buffer-reuse-window
+             display-buffer-use-some-window)
+            (reusable-frames . visible)
+            (inhibit-same-window . t)))
+    (push knayawp--commit-display-entry display-buffer-alist)))
+
+(defun knayawp--remove-commit-display-entry ()
+  "Remove the COMMIT_EDITMSG `display-buffer-alist' entry.
+Inverse of `knayawp--install-commit-display-entry'.  Idempotent."
+  (when knayawp--commit-display-entry
+    (setq display-buffer-alist
+          (delq knayawp--commit-display-entry display-buffer-alist))
+    (setq knayawp--commit-display-entry nil)))
+
+(defun knayawp--reconcile-commit-style ()
+  "Make commit-style state match the resolved value.
+Drop install bits left over from a previous resolved style, then
+install bits for the current one.  Idempotent: safe to call when
+the resolved style has not changed.
+
+Without this, changing `knayawp-magit-commit-style' at runtime
+leaves stale state behind — for example, switching from `zoom' to
+`editor' would keep the `zoom' commit-flow hooks installed.  The
+reconcile invariant is documented in `kb/properties.md' as P10."
+  (let ((style (knayawp--resolve-commit-style)))
+    ;; Remove what no longer applies under the resolved style.
+    (unless (eq style 'editor)
+      (knayawp--remove-commit-display-entry))
+    (unless (eq style 'zoom)
+      (knayawp--remove-commit-hooks))
+    ;; Install what applies under the resolved style.
+    (pcase style
+      ('editor (knayawp--install-commit-display-entry))
+      ('zoom   (knayawp--install-commit-hooks))
+      ('off    nil))))
+
 (defun knayawp--setup-magit-integration ()
   "Install magit buffer display integration.
 Save the current `magit-display-buffer-function' and replace it
-with `knayawp--magit-display-buffer'.  Depending on the resolved
-value of `knayawp-magit-commit-style', either install the
-COMMIT_EDITMSG `display-buffer-alist' entry (`editor'), install
-the commit-flow hooks (`zoom'), or do neither (`off').  Always
-add the entry that pins `magit-process-mode' buffers to the magit
-side window so long-running git commands do not pop a window in
-the editor pane."
+with `knayawp--magit-display-buffer'.  Reconcile commit-style
+state via `knayawp--reconcile-commit-style' so the hooks and
+`display-buffer-alist' entry match the current resolved value of
+`knayawp-magit-commit-style'.  Always add the entry that pins
+`magit-process-mode' buffers to the magit side window so
+long-running git commands do not pop a window in the editor
+pane."
   (when (require 'magit nil t)
     ;; Guard against double-setup: only save the original function
     ;; if we haven't already installed ours.
@@ -766,20 +825,7 @@ the editor pane."
             magit-display-buffer-function)
       (setq magit-display-buffer-function
             #'knayawp--magit-display-buffer))
-    (let ((style (knayawp--resolve-commit-style)))
-      (pcase style
-        ('editor
-         (unless knayawp--commit-display-entry
-           (setq knayawp--commit-display-entry
-                 '("COMMIT_EDITMSG"
-                   (display-buffer-reuse-window
-                    display-buffer-use-some-window)
-                   (reusable-frames . visible)
-                   (inhibit-same-window . t)))
-           (push knayawp--commit-display-entry display-buffer-alist)))
-        ('zoom
-         (knayawp--install-commit-hooks))
-        ('off nil)))
+    (knayawp--reconcile-commit-style)
     (unless knayawp--process-display-entry
       (let ((slot (knayawp--panel-slot
                    (assq 'magit knayawp-panels))))
@@ -803,10 +849,7 @@ entries, and unregister the commit-flow hooks."
     (setq magit-display-buffer-function
           knayawp--magit-saved-display-fn)
     (setq knayawp--magit-saved-display-fn nil))
-  (when knayawp--commit-display-entry
-    (setq display-buffer-alist
-          (delq knayawp--commit-display-entry display-buffer-alist))
-    (setq knayawp--commit-display-entry nil))
+  (knayawp--remove-commit-display-entry)
   (when knayawp--process-display-entry
     (setq display-buffer-alist
           (delq knayawp--process-display-entry display-buffer-alist))

--- a/knayawp.el
+++ b/knayawp.el
@@ -48,6 +48,9 @@
 (declare-function magit-status-setup-buffer "magit-status")
 (defvar magit-display-buffer-function)
 (declare-function magit-display-buffer-traditional "magit-mode")
+(defvar git-commit-setup-hook)
+(defvar with-editor-post-finish-hook)
+(defvar with-editor-post-cancel-hook)
 
 ;;;; Customization group
 
@@ -77,8 +80,68 @@
 (defcustom knayawp-magit-commit-in-editor-flag t
   "Non-nil means show COMMIT_EDITMSG in the editor pane.
 When nil, commit message buffers follow default `display-buffer'
-behavior."
+behavior.
+
+Obsolete: prefer `knayawp-magit-commit-style'.  When the user has
+not explicitly customized that new option (it is still at the
+default `zoom'), this flag is honored via a one-shot shim:
+non-nil maps to `editor' and nil maps to `off'."
   :type 'boolean
+  :group 'knayawp)
+
+(make-obsolete-variable
+ 'knayawp-magit-commit-in-editor-flag
+ "Use `knayawp-magit-commit-style' instead.
+Mapping: t -> `editor', nil -> `off'."
+ "0.1.4")
+
+(defcustom knayawp-magit-commit-style 'zoom
+  "Strategy for displaying magit commit-message buffers.
+
+`zoom' (the default) collapses the right column to just the magit
+side window and displays COMMIT_EDITMSG inside it; on commit
+finish or cancel the 3-panel layout is restored automatically.
+
+`editor' is the v0.1.3 behavior: COMMIT_EDITMSG is routed to the
+editor pane while the diff lands in the magit slot.
+
+`off' disables all special commit handling — no
+`display-buffer-alist' entry for COMMIT_EDITMSG, no commit hooks.
+Useful for users with their own magit display function.
+
+Changing this value at runtime affects future commit sessions
+only; an in-progress commit completes under the style it was
+started with.  Run \\[knayawp-layout-setup] (or tear down and
+re-create the layout) to install or remove the relevant hooks
+after a change.
+
+The `zoom' value requires `knayawp-layout-setup' to have been
+called: zoom is a no-op without an active layout.  The other two
+values are also no-ops without the layout."
+  :type '(choice (const :tag "Zoom magit slot during commit" zoom)
+                 (const :tag "Pop COMMIT_EDITMSG to editor pane" editor)
+                 (const :tag "Default magit display (no special handling)"
+                        off))
+  :group 'knayawp)
+
+(defcustom knayawp-magit-commit-focus-after 'editor
+  "Window to select after a commit finishes or is canceled.
+
+`editor' (the default) selects the editor pane, consistent with
+`knayawp-select-editor' and with the idea that magit and the
+terminals are visited briefly from the editor.
+
+`magit' selects the magit side window if one exists.
+
+`previous' restores focus to the window that was selected before
+the commit was initiated (captured in
+`knayawp--commit-pre-state').
+
+Only consulted by the `zoom' commit style; the `editor' and `off'
+styles do not place focus on commit end."
+  :type '(choice (const :tag "Editor pane" editor)
+                 (const :tag "Magit side window" magit)
+                 (const :tag "Window selected before commit" previous))
   :group 'knayawp)
 
 (defcustom knayawp-isolate-other-window-flag t
@@ -157,6 +220,20 @@ Each BUFFER-ALIST maps panel types to their buffers.")
 (defvar knayawp--zoomed-panel nil
   "Panel type symbol currently zoomed, or nil if not zoomed.")
 
+(defvar knayawp--commit-pre-state nil
+  "Plist describing the layout state captured when a commit started.
+Nil when no commit-zoom session is active.  Otherwise a plist with
+keys:
+
+  :active            Non-nil while the commit-zoom flow is in effect.
+  :was-zoomed        Panel type symbol if a manual zoom was already
+                     active, else nil.  Used to avoid double-zoom.
+  :prior-magit-buf   Buffer that was displayed in the magit slot
+                     before the commit started (defensive marker).
+  :pre-commit-window Window selected when the commit was initiated;
+                     consulted when `knayawp-magit-commit-focus-after'
+                     is `previous'.")
+
 (defvar knayawp--magit-saved-display-fn nil
   "Saved value of `magit-display-buffer-function'.")
 
@@ -180,6 +257,17 @@ Used by `knayawp--restore-right-width-on-resize' to distinguish
 external frame-size changes (where we re-apply `knayawp-right-width')
 from intra-frame window resizes (where we leave the user's choice
 alone).")
+
+(defvar knayawp--commit-hooks-installed nil
+  "Non-nil when the commit-flow hooks are registered.
+Set by `knayawp--install-commit-hooks' and cleared by
+`knayawp--remove-commit-hooks' so install/remove are idempotent.")
+
+(defvar knayawp--commit-style-shim-warned nil
+  "Non-nil after the obsolescence-shim message has been emitted.
+The shim that bridges `knayawp-magit-commit-in-editor-flag' and
+`knayawp-magit-commit-style' messages the user once per Emacs
+session.  This flag is also used by ERT to reset between tests.")
 
 ;;;; Project detection
 
@@ -360,15 +448,203 @@ so the routing is a no-op when no layout is active."
            (with-current-buffer buf
              (derived-mode-p 'magit-process-mode))))))
 
+(defun knayawp--resolve-commit-style ()
+  "Return the effective `knayawp-magit-commit-style' value.
+Honors the obsolescence shim from
+`knayawp-magit-commit-in-editor-flag': when the user explicitly
+customized the old flag and left the new option at its default
+`zoom', map the old flag to `editor' / `off' and message once.
+When both have been customized, the new variable wins (also
+messaged once)."
+  (let* ((style-customized
+          (not (eq (default-value 'knayawp-magit-commit-style) 'zoom)))
+         (old-customized
+          (not (equal (default-value 'knayawp-magit-commit-in-editor-flag)
+                      (eval (car (get 'knayawp-magit-commit-in-editor-flag
+                                      'standard-value))
+                            t)))))
+    (cond
+     ;; Old flag set, new option still default: honor the old flag.
+     ((and old-customized (not style-customized))
+      (unless knayawp--commit-style-shim-warned
+        (setq knayawp--commit-style-shim-warned t)
+        (message
+         (concat "knayawp: `knayawp-magit-commit-in-editor-flag' is "
+                 "obsolete; migrate to `knayawp-magit-commit-style'.")))
+      (if knayawp-magit-commit-in-editor-flag 'editor 'off))
+     ;; Both customized: new wins, note the override.
+     ((and old-customized style-customized)
+      (unless knayawp--commit-style-shim-warned
+        (setq knayawp--commit-style-shim-warned t)
+        (message
+         (concat "knayawp: `knayawp-magit-commit-in-editor-flag' is "
+                 "ignored because `knayawp-magit-commit-style' is set.")))
+      knayawp-magit-commit-style)
+     ;; Default path.
+     (t knayawp-magit-commit-style))))
+
+(defun knayawp--commit-flow-active-p ()
+  "Return non-nil if a commit-zoom session is currently active."
+  (and knayawp--commit-pre-state
+       (plist-get knayawp--commit-pre-state :active)))
+
+(defun knayawp--save-commit-pre-state (magit-slot)
+  "Capture pre-commit layout state into `knayawp--commit-pre-state'.
+MAGIT-SLOT is the integer slot of the magit side window."
+  (let* ((magit-win (knayawp--side-window-for-slot magit-slot))
+         (prior-buf (and magit-win (window-buffer magit-win))))
+    (setq knayawp--commit-pre-state
+          (list :active            t
+                :was-zoomed        knayawp--zoomed-panel
+                :prior-magit-buf   prior-buf
+                :pre-commit-window (selected-window)))))
+
+(defun knayawp--focus-target-window ()
+  "Return the window to select after a commit finishes or cancels.
+Driven by `knayawp-magit-commit-focus-after'.  Falls back to the
+editor pane when the requested target is not available."
+  (pcase knayawp-magit-commit-focus-after
+    ('editor
+     (seq-find (lambda (win)
+                 (not (window-parameter win 'window-side)))
+               (window-list)))
+    ('magit
+     (let ((magit-spec (assq 'magit knayawp-panels)))
+       (or (and magit-spec
+                (knayawp--side-window-for-slot
+                 (knayawp--panel-slot magit-spec)))
+           (seq-find (lambda (win)
+                       (not (window-parameter win 'window-side)))
+                     (window-list)))))
+    ('previous
+     (let ((win (and knayawp--commit-pre-state
+                     (plist-get knayawp--commit-pre-state
+                                :pre-commit-window))))
+       (if (and win (window-live-p win))
+           win
+         (seq-find (lambda (w)
+                     (not (window-parameter w 'window-side)))
+                   (window-list)))))
+    (_
+     (seq-find (lambda (win)
+                 (not (window-parameter win 'window-side)))
+               (window-list)))))
+
+(defun knayawp--restore-commit-pre-state ()
+  "Reset `knayawp--commit-pre-state' and place focus.
+Does not perform a window-configuration restore: `with-editor'
+already restored the pre-commit layout via
+`with-editor-previous-winconf' before this runs.  Honors
+`knayawp-magit-commit-focus-after' for the focus target."
+  (let ((target (knayawp--focus-target-window)))
+    (setq knayawp--commit-pre-state nil)
+    (when (and target (window-live-p target))
+      (select-window target))))
+
+(defun knayawp--apply-zoom-solo-magit ()
+  "Zoom the layout down to just the magit side window.
+Thin wrapper around the existing zoom machinery.  Kept as a
+named entry point so the v0.3.0 layout-system refactor (issue
+#70) is a one-function change."
+  (let* ((magit-spec (assq 'magit knayawp-panels))
+         (slot (and magit-spec (knayawp--panel-slot magit-spec)))
+         (magit-win (and slot (knayawp--side-window-for-slot slot))))
+    (when magit-win
+      (dolist (win (knayawp--side-windows))
+        (unless (eq (window-parameter win 'window-slot) slot)
+          (delete-window win)))
+      (setq knayawp--zoomed-panel (knayawp--panel-type magit-spec)))))
+
+(defun knayawp--commit-flow-start ()
+  "Enter the commit-zoom mode.
+Capture state into `knayawp--commit-pre-state', zoom the magit
+slot via `knayawp--apply-zoom-solo-magit', and select the
+COMMIT_EDITMSG buffer when the current buffer is a git-commit
+buffer."
+  (let* ((magit-spec (assq 'magit knayawp-panels))
+         (slot (and magit-spec (knayawp--panel-slot magit-spec))))
+    (when slot
+      (knayawp--save-commit-pre-state slot)
+      ;; Skip the zoom step when a manual zoom is already active so
+      ;; we don't clobber the user's preferred slot.
+      (unless (plist-get knayawp--commit-pre-state :was-zoomed)
+        (knayawp--apply-zoom-solo-magit))
+      ;; Ensure the COMMIT_EDITMSG buffer is selected in the magit
+      ;; slot.  `git-commit-setup-hook' runs with current-buffer
+      ;; already set to COMMIT_EDITMSG, so reuse it.
+      (let ((commit-buf (current-buffer))
+            (magit-win (knayawp--side-window-for-slot slot)))
+        (when (and magit-win (window-live-p magit-win))
+          (set-window-buffer magit-win commit-buf)
+          (select-window magit-win))))))
+
+(defun knayawp--commit-flow-end ()
+  "Exit the commit-zoom mode.
+Idempotent: if no commit-flow session is active, do nothing.
+Otherwise clear the state plist and place focus per
+`knayawp-magit-commit-focus-after'."
+  (when (knayawp--commit-flow-active-p)
+    (knayawp--restore-commit-pre-state)))
+
+(defun knayawp--git-commit-setup-handler ()
+  "Hook function for `git-commit-setup-hook'.
+Activate the commit-zoom flow when (a) a knayawp layout is active
+in the current frame, (b) `knayawp-magit-commit-style' resolves to
+`zoom', and (c) no commit-flow session is already in progress."
+  (let* ((magit-spec (assq 'magit knayawp-panels))
+         (magit-win (and magit-spec
+                         (knayawp--side-window-for-slot
+                          (knayawp--panel-slot magit-spec)))))
+    (when (and magit-win
+               (eq (knayawp--resolve-commit-style) 'zoom)
+               (not (knayawp--commit-flow-active-p)))
+      (knayawp--commit-flow-start))))
+
+(defun knayawp--with-editor-finish-handler ()
+  "Hook function for `with-editor-post-finish-hook'.
+Run `knayawp--commit-flow-end' when our flow is active."
+  (knayawp--commit-flow-end))
+
+(defun knayawp--with-editor-cancel-handler ()
+  "Hook function for `with-editor-post-cancel-hook'.
+Run `knayawp--commit-flow-end' when our flow is active."
+  (knayawp--commit-flow-end))
+
+(defun knayawp--install-commit-hooks ()
+  "Register knayawp's commit-flow handlers on the relevant hooks.
+Idempotent.  Called from `knayawp--setup-magit-integration' when
+the resolved commit style is `zoom'."
+  (unless knayawp--commit-hooks-installed
+    (add-hook 'git-commit-setup-hook
+              #'knayawp--git-commit-setup-handler)
+    (add-hook 'with-editor-post-finish-hook
+              #'knayawp--with-editor-finish-handler)
+    (add-hook 'with-editor-post-cancel-hook
+              #'knayawp--with-editor-cancel-handler)
+    (setq knayawp--commit-hooks-installed t)))
+
+(defun knayawp--remove-commit-hooks ()
+  "Unregister knayawp's commit-flow handlers.
+Inverse of `knayawp--install-commit-hooks'.  Idempotent."
+  (when knayawp--commit-hooks-installed
+    (remove-hook 'git-commit-setup-hook
+                 #'knayawp--git-commit-setup-handler)
+    (remove-hook 'with-editor-post-finish-hook
+                 #'knayawp--with-editor-finish-handler)
+    (remove-hook 'with-editor-post-cancel-hook
+                 #'knayawp--with-editor-cancel-handler)
+    (setq knayawp--commit-hooks-installed nil)))
+
 (defun knayawp--setup-magit-integration ()
   "Install magit buffer display integration.
 Save the current `magit-display-buffer-function' and replace it
-with `knayawp--magit-display-buffer'.  If
-`knayawp-magit-commit-in-editor-flag' is non-nil, add a
-`display-buffer-alist' entry to route COMMIT_EDITMSG to the
-editor pane.  Also add an entry that pins `magit-process-mode'
-buffers to the magit side window so long-running git commands do
-not pop a window in the editor pane."
+with `knayawp--magit-display-buffer'.  Depending on the resolved
+value of `knayawp-magit-commit-style', either install the
+COMMIT_EDITMSG `display-buffer-alist' entry (`editor'), install
+the commit-flow hooks (`zoom'), or do neither (`off').  Always
+add the entry that pins `magit-process-mode' buffers to the magit
+side window so long-running git commands do not pop a window in
+the editor pane."
   (when (require 'magit nil t)
     ;; Guard against double-setup: only save the original function
     ;; if we haven't already installed ours.
@@ -378,15 +654,20 @@ not pop a window in the editor pane."
             magit-display-buffer-function)
       (setq magit-display-buffer-function
             #'knayawp--magit-display-buffer))
-    (when (and knayawp-magit-commit-in-editor-flag
-               (not knayawp--commit-display-entry))
-      (setq knayawp--commit-display-entry
-            '("COMMIT_EDITMSG"
-              (display-buffer-reuse-window
-               display-buffer-use-some-window)
-              (reusable-frames . visible)
-              (inhibit-same-window . t)))
-      (push knayawp--commit-display-entry display-buffer-alist))
+    (let ((style (knayawp--resolve-commit-style)))
+      (pcase style
+        ('editor
+         (unless knayawp--commit-display-entry
+           (setq knayawp--commit-display-entry
+                 '("COMMIT_EDITMSG"
+                   (display-buffer-reuse-window
+                    display-buffer-use-some-window)
+                   (reusable-frames . visible)
+                   (inhibit-same-window . t)))
+           (push knayawp--commit-display-entry display-buffer-alist)))
+        ('zoom
+         (knayawp--install-commit-hooks))
+        ('off nil)))
     (unless knayawp--process-display-entry
       (let ((slot (knayawp--panel-slot
                    (assq 'magit knayawp-panels))))
@@ -403,9 +684,9 @@ not pop a window in the editor pane."
 
 (defun knayawp--teardown-magit-integration ()
   "Remove magit buffer display integration.
-Restore the saved `magit-display-buffer-function' and remove the
+Restore the saved `magit-display-buffer-function', remove the
 COMMIT_EDITMSG and `magit-process-mode' `display-buffer-alist'
-entries."
+entries, and unregister the commit-flow hooks."
   (when knayawp--magit-saved-display-fn
     (setq magit-display-buffer-function
           knayawp--magit-saved-display-fn)
@@ -417,7 +698,8 @@ entries."
   (when knayawp--process-display-entry
     (setq display-buffer-alist
           (delq knayawp--process-display-entry display-buffer-alist))
-    (setq knayawp--process-display-entry nil)))
+    (setq knayawp--process-display-entry nil))
+  (knayawp--remove-commit-hooks))
 
 ;;;; Layout engine
 
@@ -470,8 +752,13 @@ left and is selected when done."
 
 (defun knayawp-layout-teardown ()
   "Remove the knayawp control pane from the current frame.
-Delete all side windows but do not kill their buffers."
+Delete all side windows but do not kill their buffers.  If a
+commit-zoom session was active, discard its state and warn."
   (interactive)
+  (when (knayawp--commit-flow-active-p)
+    (setq knayawp--commit-pre-state nil)
+    (message
+     "knayawp: layout torn down during active commit; state cleared"))
   (knayawp--teardown-magit-integration)
   (let ((side-windows (knayawp--side-windows)))
     (dolist (win side-windows)

--- a/knayawp.el
+++ b/knayawp.el
@@ -494,13 +494,19 @@ messaged once)."
   (and knayawp--commit-pre-state
        (plist-get knayawp--commit-pre-state :active)))
 
-(defun knayawp--save-commit-pre-state (magit-slot &optional commit-buffer)
+(defun knayawp--save-commit-pre-state (magit-slot &optional commit-buffer
+                                                  winconf)
   "Capture pre-commit layout state into `knayawp--commit-pre-state'.
 MAGIT-SLOT is the integer slot of the magit side window.
 COMMIT-BUFFER, when non-nil, is the COMMIT_EDITMSG buffer that the
 commit-flow will place in the magit slot; it is recorded so the
 late `server-switch-hook' handler can re-select it after magit's
-`magit-commit-diff-while-committing' pushes the diff on top."
+`magit-commit-diff-while-committing' pushes the diff on top.
+WINCONF, when non-nil, is the window configuration captured by
+`knayawp--commit-flow-start' *before* the zoom step ran; it is
+the only snapshot that still contains the terminal and Claude
+side windows, and `knayawp--restore-commit-pre-state' uses it to
+override the stale layout that `with-editor' restored."
   (let* ((magit-win (knayawp--side-window-for-slot magit-slot))
          (prior-buf (and magit-win (window-buffer magit-win))))
     (setq knayawp--commit-pre-state
@@ -508,7 +514,8 @@ late `server-switch-hook' handler can re-select it after magit's
                 :was-zoomed        knayawp--zoomed-panel
                 :prior-magit-buf   prior-buf
                 :commit-buffer     commit-buffer
-                :pre-commit-window (selected-window)))))
+                :pre-commit-window (selected-window)
+                :winconf           winconf))))
 
 (defun knayawp--focus-target-window ()
   "Return the window to select after a commit finishes or cancels.
@@ -542,47 +549,73 @@ editor pane when the requested target is not available."
                (window-list)))))
 
 (defun knayawp--restore-commit-pre-state ()
-  "Reset commit-flow state, refresh the magit slot, and place focus.
-Does not perform a window-configuration restore: `with-editor'
-already restored the pre-commit layout via
-`with-editor-previous-winconf' before this runs.
+  "Restore the pre-zoom layout, refresh the magit slot, place focus.
+The `with-editor' restore that ran just before this function uses
+`with-editor-previous-winconf', captured *after* our
+`knayawp--git-commit-setup-handler' had already zoomed the
+layout.  That snapshot therefore only contains the magit slot —
+the terminal and Claude side windows are gone.  To get them back
+we restore the winconf knayawp captured itself in
+`knayawp--commit-flow-start' before the zoom step ran.
 
-Three side-effects, in order:
+Four side-effects, in order:
 
-1. Reset `knayawp--zoomed-panel' to the saved `:was-zoomed' value
+1. When `:winconf' is present and its frame matches the selected
+   frame, call `set-window-configuration' on it to reinstate the
+   full 3-panel layout (fixes the round 3 bug: only one side
+   window left after the commit-finish keybinding).
+
+2. Reset `knayawp--zoomed-panel' to the saved `:was-zoomed' value
    so a subsequent commit can re-zoom (fixes Bug B: second commit
    in the same session did not zoom).
 
-2. When the user was not in a manual zoom before the flow, replace
-   whatever buffer `with-editor' restored into the magit slot
+3. When the user was not in a manual zoom before the flow, replace
+   whatever buffer the restored winconf left in the magit slot
    (typically `*magit-diff*' because `magit-commit-create' shows
-   the diff synchronously before invoking `with-editor', so the
-   `with-editor-previous-winconf' snapshot already contains it)
-   with the project's `magit-status' buffer (fixes Bug A).
+   the diff synchronously before our setup handler captured the
+   winconf) with the project's `magit-status' buffer (fixes Bug A).
 
-3. Place focus according to `knayawp-magit-commit-focus-after'."
-  (let* ((target (knayawp--focus-target-window))
-         (was-zoomed (and knayawp--commit-pre-state
+4. Place focus according to `knayawp-magit-commit-focus-after'.
+
+The magit-window lookup happens AFTER the winconf restore because
+the pre-restore window tree contains only the zoomed slot, and
+the post-restore lookup gives us the live window inside the
+re-expanded layout."
+  (let* ((was-zoomed (and knayawp--commit-pre-state
                           (plist-get knayawp--commit-pre-state
                                      :was-zoomed)))
-         (magit-spec (assq 'magit knayawp-panels))
-         (slot (and magit-spec (knayawp--panel-slot magit-spec)))
-         (magit-win (and slot (knayawp--side-window-for-slot slot))))
-    ;; (1) Restore the pre-flow zoom state (nil or the manual zoom
-    ;; symbol the user had active before they ran `c c').
-    (setq knayawp--zoomed-panel was-zoomed)
-    ;; (2) Re-display magit-status in the magit slot, unless the user
-    ;; was in a manual zoom (in which case the slot is theirs).
-    (unless was-zoomed
-      (when (and magit-win (window-live-p magit-win)
-                 (fboundp 'magit-mode-get-buffer))
-        (let ((status-buf (magit-mode-get-buffer 'magit-status-mode)))
-          (when (and status-buf (buffer-live-p status-buf))
-            (set-window-buffer magit-win status-buf)))))
-    (setq knayawp--commit-pre-state nil)
-    ;; (3) Place focus per `knayawp-magit-commit-focus-after'.
-    (when (and target (window-live-p target))
-      (select-window target))))
+         (winconf (and knayawp--commit-pre-state
+                       (plist-get knayawp--commit-pre-state
+                                  :winconf))))
+    ;; (1) Restore the pre-zoom layout when the saved winconf still
+    ;; belongs to the current frame.  Cross-frame restore would crash
+    ;; or scramble the layout, so be conservative.
+    (when (and winconf
+               (window-configuration-p winconf)
+               (eq (window-configuration-frame winconf)
+                   (selected-frame)))
+      (set-window-configuration winconf))
+    ;; Magit-window and focus-target lookups MUST happen after the
+    ;; restore: pre-restore the window tree is the zoomed one.
+    (let* ((target (knayawp--focus-target-window))
+           (magit-spec (assq 'magit knayawp-panels))
+           (slot (and magit-spec (knayawp--panel-slot magit-spec)))
+           (magit-win (and slot (knayawp--side-window-for-slot slot))))
+      ;; (2) Restore the pre-flow zoom state (nil or the manual zoom
+      ;; symbol the user had active before they ran `c c').
+      (setq knayawp--zoomed-panel was-zoomed)
+      ;; (3) Re-display magit-status in the magit slot, unless the
+      ;; user was in a manual zoom (in which case the slot is theirs).
+      (unless was-zoomed
+        (when (and magit-win (window-live-p magit-win)
+                   (fboundp 'magit-mode-get-buffer))
+          (let ((status-buf (magit-mode-get-buffer 'magit-status-mode)))
+            (when (and status-buf (buffer-live-p status-buf))
+              (set-window-buffer magit-win status-buf)))))
+      (setq knayawp--commit-pre-state nil)
+      ;; (4) Place focus per `knayawp-magit-commit-focus-after'.
+      (when (and target (window-live-p target))
+        (select-window target)))))
 
 (defun knayawp--apply-zoom-solo-magit ()
   "Zoom the layout down to just the magit side window.
@@ -600,15 +633,26 @@ named entry point so the v0.3.0 layout-system refactor (issue
 
 (defun knayawp--commit-flow-start ()
   "Enter the commit-zoom mode.
-Capture state into `knayawp--commit-pre-state', zoom the magit
-slot via `knayawp--apply-zoom-solo-magit', and select the
-COMMIT_EDITMSG buffer when the current buffer is a git-commit
-buffer."
+Capture the pre-zoom window configuration (so
+`knayawp--restore-commit-pre-state' can reinstate the full
+3-panel layout on finish) and the rest of the pre-commit state
+into `knayawp--commit-pre-state', zoom the magit slot via
+`knayawp--apply-zoom-solo-magit', and select the COMMIT_EDITMSG
+buffer when the current buffer is a git-commit buffer.
+
+The winconf capture must run BEFORE the zoom step: the zoom
+deletes the terminal and Claude side windows, and we need a
+snapshot that still contains them so the restore step can bring
+them back.  `with-editor' captures its own winconf later (in
+`with-editor-mode'), but by then the layout has already been
+zoomed and that snapshot is useless for restoring the side
+windows."
   (let* ((magit-spec (assq 'magit knayawp-panels))
          (slot (and magit-spec (knayawp--panel-slot magit-spec)))
-         (commit-buf (current-buffer)))
+         (commit-buf (current-buffer))
+         (winconf (current-window-configuration)))
     (when slot
-      (knayawp--save-commit-pre-state slot commit-buf)
+      (knayawp--save-commit-pre-state slot commit-buf winconf)
       ;; Skip the zoom step when a manual zoom is already active so
       ;; we don't clobber the user's preferred slot.
       (unless (plist-get knayawp--commit-pre-state :was-zoomed)

--- a/knayawp.el
+++ b/knayawp.el
@@ -51,6 +51,7 @@
 (defvar git-commit-setup-hook)
 (defvar with-editor-post-finish-hook)
 (defvar with-editor-post-cancel-hook)
+(defvar server-switch-hook)
 
 ;;;; Customization group
 
@@ -230,6 +231,10 @@ keys:
                      active, else nil.  Used to avoid double-zoom.
   :prior-magit-buf   Buffer that was displayed in the magit slot
                      before the commit started (defensive marker).
+  :commit-buffer     The COMMIT_EDITMSG buffer placed in the magit
+                     slot when the zoom started.  Re-selected by the
+                     `server-switch-hook' handler so it survives the
+                     `magit-commit-diff-while-committing' race.
   :pre-commit-window Window selected when the commit was initiated;
                      consulted when `knayawp-magit-commit-focus-after'
                      is `previous'.")
@@ -488,15 +493,20 @@ messaged once)."
   (and knayawp--commit-pre-state
        (plist-get knayawp--commit-pre-state :active)))
 
-(defun knayawp--save-commit-pre-state (magit-slot)
+(defun knayawp--save-commit-pre-state (magit-slot &optional commit-buffer)
   "Capture pre-commit layout state into `knayawp--commit-pre-state'.
-MAGIT-SLOT is the integer slot of the magit side window."
+MAGIT-SLOT is the integer slot of the magit side window.
+COMMIT-BUFFER, when non-nil, is the COMMIT_EDITMSG buffer that the
+commit-flow will place in the magit slot; it is recorded so the
+late `server-switch-hook' handler can re-select it after magit's
+`magit-commit-diff-while-committing' pushes the diff on top."
   (let* ((magit-win (knayawp--side-window-for-slot magit-slot))
          (prior-buf (and magit-win (window-buffer magit-win))))
     (setq knayawp--commit-pre-state
           (list :active            t
                 :was-zoomed        knayawp--zoomed-panel
                 :prior-magit-buf   prior-buf
+                :commit-buffer     commit-buffer
                 :pre-commit-window (selected-window)))))
 
 (defun knayawp--focus-target-window ()
@@ -562,9 +572,10 @@ slot via `knayawp--apply-zoom-solo-magit', and select the
 COMMIT_EDITMSG buffer when the current buffer is a git-commit
 buffer."
   (let* ((magit-spec (assq 'magit knayawp-panels))
-         (slot (and magit-spec (knayawp--panel-slot magit-spec))))
+         (slot (and magit-spec (knayawp--panel-slot magit-spec)))
+         (commit-buf (current-buffer)))
     (when slot
-      (knayawp--save-commit-pre-state slot)
+      (knayawp--save-commit-pre-state slot commit-buf)
       ;; Skip the zoom step when a manual zoom is already active so
       ;; we don't clobber the user's preferred slot.
       (unless (plist-get knayawp--commit-pre-state :was-zoomed)
@@ -572,8 +583,7 @@ buffer."
       ;; Ensure the COMMIT_EDITMSG buffer is selected in the magit
       ;; slot.  `git-commit-setup-hook' runs with current-buffer
       ;; already set to COMMIT_EDITMSG, so reuse it.
-      (let ((commit-buf (current-buffer))
-            (magit-win (knayawp--side-window-for-slot slot)))
+      (let ((magit-win (knayawp--side-window-for-slot slot)))
         (when (and magit-win (window-live-p magit-win))
           (set-window-buffer magit-win commit-buf)
           (select-window magit-win))))))
@@ -610,10 +620,31 @@ Run `knayawp--commit-flow-end' when our flow is active."
 Run `knayawp--commit-flow-end' when our flow is active."
   (knayawp--commit-flow-end))
 
+(defun knayawp--server-switch-handler ()
+  "Hook function for `server-switch-hook'.
+Re-assert COMMIT_EDITMSG in the magit side window after the
+emacsclient server switch completes.  Installed with the APPEND
+flag so it runs after `magit-commit-diff-while-committing', which
+otherwise lands `*magit-diff*' in the zoomed magit slot and steals
+focus.  No-op unless a commit-flow session is active."
+  (when (knayawp--commit-flow-active-p)
+    (let* ((magit-spec (assq 'magit knayawp-panels))
+           (slot (and magit-spec (knayawp--panel-slot magit-spec)))
+           (magit-win (and slot (knayawp--side-window-for-slot slot)))
+           (commit-buf (plist-get knayawp--commit-pre-state
+                                  :commit-buffer)))
+      (when (and magit-win
+                 (window-live-p magit-win)
+                 (buffer-live-p commit-buf))
+        (set-window-buffer magit-win commit-buf)
+        (select-window magit-win)))))
+
 (defun knayawp--install-commit-hooks ()
   "Register knayawp's commit-flow handlers on the relevant hooks.
 Idempotent.  Called from `knayawp--setup-magit-integration' when
-the resolved commit style is `zoom'."
+the resolved commit style is `zoom'.  The `server-switch-hook'
+entry is installed with APPEND so it runs after magit's own
+`magit-commit-diff-while-committing', winning the focus race."
   (unless knayawp--commit-hooks-installed
     (add-hook 'git-commit-setup-hook
               #'knayawp--git-commit-setup-handler)
@@ -621,6 +652,8 @@ the resolved commit style is `zoom'."
               #'knayawp--with-editor-finish-handler)
     (add-hook 'with-editor-post-cancel-hook
               #'knayawp--with-editor-cancel-handler)
+    (add-hook 'server-switch-hook
+              #'knayawp--server-switch-handler t)
     (setq knayawp--commit-hooks-installed t)))
 
 (defun knayawp--remove-commit-hooks ()
@@ -633,6 +666,8 @@ Inverse of `knayawp--install-commit-hooks'.  Idempotent."
                  #'knayawp--with-editor-finish-handler)
     (remove-hook 'with-editor-post-cancel-hook
                  #'knayawp--with-editor-cancel-handler)
+    (remove-hook 'server-switch-hook
+                 #'knayawp--server-switch-handler)
     (setq knayawp--commit-hooks-installed nil)))
 
 (defun knayawp--setup-magit-integration ()

--- a/knayawp.el
+++ b/knayawp.el
@@ -52,6 +52,7 @@
 (defvar with-editor-post-finish-hook)
 (defvar with-editor-post-cancel-hook)
 (defvar server-switch-hook)
+(declare-function magit-mode-get-buffer "magit-mode")
 
 ;;;; Customization group
 
@@ -541,13 +542,45 @@ editor pane when the requested target is not available."
                (window-list)))))
 
 (defun knayawp--restore-commit-pre-state ()
-  "Reset `knayawp--commit-pre-state' and place focus.
+  "Reset commit-flow state, refresh the magit slot, and place focus.
 Does not perform a window-configuration restore: `with-editor'
 already restored the pre-commit layout via
-`with-editor-previous-winconf' before this runs.  Honors
-`knayawp-magit-commit-focus-after' for the focus target."
-  (let ((target (knayawp--focus-target-window)))
+`with-editor-previous-winconf' before this runs.
+
+Three side-effects, in order:
+
+1. Reset `knayawp--zoomed-panel' to the saved `:was-zoomed' value
+   so a subsequent commit can re-zoom (fixes Bug B: second commit
+   in the same session did not zoom).
+
+2. When the user was not in a manual zoom before the flow, replace
+   whatever buffer `with-editor' restored into the magit slot
+   (typically `*magit-diff*' because `magit-commit-create' shows
+   the diff synchronously before invoking `with-editor', so the
+   `with-editor-previous-winconf' snapshot already contains it)
+   with the project's `magit-status' buffer (fixes Bug A).
+
+3. Place focus according to `knayawp-magit-commit-focus-after'."
+  (let* ((target (knayawp--focus-target-window))
+         (was-zoomed (and knayawp--commit-pre-state
+                          (plist-get knayawp--commit-pre-state
+                                     :was-zoomed)))
+         (magit-spec (assq 'magit knayawp-panels))
+         (slot (and magit-spec (knayawp--panel-slot magit-spec)))
+         (magit-win (and slot (knayawp--side-window-for-slot slot))))
+    ;; (1) Restore the pre-flow zoom state (nil or the manual zoom
+    ;; symbol the user had active before they ran `c c').
+    (setq knayawp--zoomed-panel was-zoomed)
+    ;; (2) Re-display magit-status in the magit slot, unless the user
+    ;; was in a manual zoom (in which case the slot is theirs).
+    (unless was-zoomed
+      (when (and magit-win (window-live-p magit-win)
+                 (fboundp 'magit-mode-get-buffer))
+        (let ((status-buf (magit-mode-get-buffer 'magit-status-mode)))
+          (when (and status-buf (buffer-live-p status-buf))
+            (set-window-buffer magit-win status-buf)))))
     (setq knayawp--commit-pre-state nil)
+    ;; (3) Place focus per `knayawp-magit-commit-focus-after'.
     (when (and target (window-live-p target))
       (select-window target))))
 

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -1235,4 +1235,85 @@ Two sub-cases:
       (when (buffer-live-p diff-buf) (kill-buffer diff-buf))
       (when (buffer-live-p status-buf) (kill-buffer status-buf)))))
 
+(ert-deftest knayawp-test-commit-flow-start-captures-winconf ()
+  "`knayawp--commit-flow-start' records the pre-zoom winconf.
+Round 3 of PR #76 sandbox testing showed only one side window
+remaining after `C-c C-c': `with-editor-previous-winconf' was
+captured AFTER our setup handler had already zoomed the layout,
+so the snapshot only contained the magit slot.
+
+The fix is for knayawp to capture its own winconf in
+`knayawp--commit-flow-start' before the zoom step.  This test
+exercises just the capture: invoking the flow-start in a
+controlled context must populate the `:winconf' plist key with a
+`window-configuration-p' object."
+  (let ((knayawp--commit-pre-state nil)
+        (knayawp--zoomed-panel nil)
+        (knayawp-panels '((magit :slot -1)
+                          (terminal :slot 0)
+                          (claude :slot 1))))
+    (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+               (lambda (_slot) (selected-window)))
+              ((symbol-function 'knayawp--apply-zoom-solo-magit)
+               #'ignore))
+      (knayawp--commit-flow-start)
+      (should (plist-member knayawp--commit-pre-state :winconf))
+      (should (window-configuration-p
+               (plist-get knayawp--commit-pre-state :winconf))))
+    (setq knayawp--commit-pre-state nil)))
+
+(ert-deftest knayawp-test-restore-commit-pre-state-restores-winconf ()
+  "Restore step calls `set-window-configuration' on the saved winconf.
+The saved winconf snapshots the layout BEFORE the zoom step, so
+restoring it brings back the terminal and Claude side windows
+that `with-editor's later restore could not."
+  (let* ((sentinel (current-window-configuration))
+         (called-with 'unset)
+         (knayawp--zoomed-panel nil)
+         (knayawp--commit-pre-state
+          (list :active t
+                :was-zoomed nil
+                :prior-magit-buf nil
+                :commit-buffer nil
+                :pre-commit-window (selected-window)
+                :winconf sentinel)))
+    (cl-letf (((symbol-function 'set-window-configuration)
+               (lambda (wc &rest _) (setq called-with wc)))
+              ((symbol-function 'window-configuration-frame)
+               (lambda (_wc) (selected-frame)))
+              ((symbol-function 'knayawp--side-window-for-slot)
+               (lambda (_slot) nil))
+              ((symbol-function 'knayawp--focus-target-window)
+               (lambda () nil)))
+      (knayawp--restore-commit-pre-state)
+      (should (eq called-with sentinel)))))
+
+(ert-deftest knayawp-test-restore-commit-pre-state-skips-winconf-wrong-frame ()
+  "Restore step does NOT touch winconf when its frame is gone.
+Cross-frame restores can crash or scramble the layout when the
+recorded frame is no longer selected.  The guard checks
+`window-configuration-frame' against `selected-frame' and skips
+the restore on mismatch."
+  (let* ((sentinel (current-window-configuration))
+         (other-frame (cons 'fake-frame 'sentinel))
+         (called-with 'unset)
+         (knayawp--zoomed-panel nil)
+         (knayawp--commit-pre-state
+          (list :active t
+                :was-zoomed nil
+                :prior-magit-buf nil
+                :commit-buffer nil
+                :pre-commit-window (selected-window)
+                :winconf sentinel)))
+    (cl-letf (((symbol-function 'set-window-configuration)
+               (lambda (wc &rest _) (setq called-with wc)))
+              ((symbol-function 'window-configuration-frame)
+               (lambda (_wc) other-frame))
+              ((symbol-function 'knayawp--side-window-for-slot)
+               (lambda (_slot) nil))
+              ((symbol-function 'knayawp--focus-target-window)
+               (lambda () nil)))
+      (knayawp--restore-commit-pre-state)
+      (should (eq called-with 'unset)))))
+
 ;;; knayawp-test.el ends here

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -795,4 +795,229 @@ helper."
       (knayawp--restore-right-width-on-resize (selected-frame))
       (should (= 1 calls)))))
 
+;;;; Commit flow (#48, #53)
+
+(ert-deftest knayawp-test-commit-style-default ()
+  "`knayawp-magit-commit-style' defaults to `zoom'."
+  (should (eq 'zoom (default-value 'knayawp-magit-commit-style))))
+
+(ert-deftest knayawp-test-commit-style-obsolete-shim-editor ()
+  "Old flag = t maps to `editor' when new option is default.
+Setup installs a COMMIT_EDITMSG `display-buffer-alist' entry and
+no commit hooks."
+  (when (require 'magit nil t)
+    (let ((original magit-display-buffer-function)
+          (knayawp--magit-saved-display-fn nil)
+          (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
+          (knayawp--commit-hooks-installed nil)
+          (knayawp--commit-style-shim-warned t)
+          (knayawp-magit-commit-style 'zoom)
+          (knayawp-magit-commit-in-editor-flag t)
+          (display-buffer-alist nil))
+      (unwind-protect
+          (progn
+            ;; Simulate "user explicitly set the old flag" by changing
+            ;; the default-value via cl-letf'd default-value lookup;
+            ;; here we rely on the let-binding above already differing
+            ;; from the standard value (t == default), so we force the
+            ;; old-customized branch by stubbing default-value lookup.
+            (cl-letf (((symbol-function 'default-value)
+                       (lambda (sym)
+                         (pcase sym
+                           ('knayawp-magit-commit-style 'zoom)
+                           ('knayawp-magit-commit-in-editor-flag nil)
+                           (_ (symbol-value sym))))))
+              (knayawp--setup-magit-integration))
+            (should (seq-find
+                     (lambda (e)
+                       (and (stringp (car e))
+                            (string-match-p "COMMIT_EDITMSG"
+                                            (car e))))
+                     display-buffer-alist))
+            (should-not (memq #'knayawp--git-commit-setup-handler
+                              git-commit-setup-hook))
+            (knayawp--teardown-magit-integration))
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-commit-style-obsolete-shim-off ()
+  "Old flag = nil maps to `off' when new option is default.
+Setup installs no COMMIT_EDITMSG entry and no commit hooks."
+  (when (require 'magit nil t)
+    (let ((original magit-display-buffer-function)
+          (knayawp--magit-saved-display-fn nil)
+          (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
+          (knayawp--commit-hooks-installed nil)
+          (knayawp--commit-style-shim-warned t)
+          (knayawp-magit-commit-style 'zoom)
+          (knayawp-magit-commit-in-editor-flag nil)
+          (display-buffer-alist nil))
+      (unwind-protect
+          (progn
+            (cl-letf (((symbol-function 'default-value)
+                       (lambda (sym)
+                         (pcase sym
+                           ('knayawp-magit-commit-style 'zoom)
+                           ('knayawp-magit-commit-in-editor-flag t)
+                           (_ (symbol-value sym))))))
+              (knayawp--setup-magit-integration))
+            (should-not (seq-find
+                         (lambda (e)
+                           (and (stringp (car e))
+                                (string-match-p "COMMIT_EDITMSG"
+                                                (car e))))
+                         display-buffer-alist))
+            (should-not (memq #'knayawp--git-commit-setup-handler
+                              git-commit-setup-hook))
+            (knayawp--teardown-magit-integration))
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-commit-hooks-installed-when-zoom ()
+  "With style = `zoom', setup installs all three commit hooks."
+  (when (require 'magit nil t)
+    (let ((original magit-display-buffer-function)
+          (knayawp--magit-saved-display-fn nil)
+          (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
+          (knayawp--commit-hooks-installed nil)
+          (knayawp--commit-style-shim-warned t)
+          (knayawp-magit-commit-style 'zoom)
+          (knayawp-magit-commit-in-editor-flag t)
+          (git-commit-setup-hook nil)
+          (with-editor-post-finish-hook nil)
+          (with-editor-post-cancel-hook nil)
+          (display-buffer-alist nil))
+      (unwind-protect
+          (progn
+            (knayawp--setup-magit-integration)
+            (should (memq #'knayawp--git-commit-setup-handler
+                          git-commit-setup-hook))
+            (should (memq #'knayawp--with-editor-finish-handler
+                          with-editor-post-finish-hook))
+            (should (memq #'knayawp--with-editor-cancel-handler
+                          with-editor-post-cancel-hook))
+            (should knayawp--commit-hooks-installed))
+        (knayawp--teardown-magit-integration)
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-commit-hooks-removed-on-teardown ()
+  "Teardown unregisters all three commit-flow handlers."
+  (when (require 'magit nil t)
+    (let ((original magit-display-buffer-function)
+          (knayawp--magit-saved-display-fn nil)
+          (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
+          (knayawp--commit-hooks-installed nil)
+          (knayawp--commit-style-shim-warned t)
+          (knayawp-magit-commit-style 'zoom)
+          (knayawp-magit-commit-in-editor-flag t)
+          (git-commit-setup-hook nil)
+          (with-editor-post-finish-hook nil)
+          (with-editor-post-cancel-hook nil)
+          (display-buffer-alist nil))
+      (unwind-protect
+          (progn
+            (knayawp--setup-magit-integration)
+            (knayawp--teardown-magit-integration)
+            (should-not (memq #'knayawp--git-commit-setup-handler
+                              git-commit-setup-hook))
+            (should-not (memq #'knayawp--with-editor-finish-handler
+                              with-editor-post-finish-hook))
+            (should-not (memq #'knayawp--with-editor-cancel-handler
+                              with-editor-post-cancel-hook))
+            (should-not knayawp--commit-hooks-installed))
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-commit-pre-state-shape ()
+  "`knayawp--save-commit-pre-state' populates all expected plist keys."
+  (let ((knayawp--commit-pre-state nil)
+        (knayawp--zoomed-panel nil))
+    (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+               (lambda (_slot) nil)))
+      (knayawp--save-commit-pre-state -1))
+    (should (plist-member knayawp--commit-pre-state :active))
+    (should (plist-member knayawp--commit-pre-state :was-zoomed))
+    (should (plist-member knayawp--commit-pre-state :prior-magit-buf))
+    (should (plist-member knayawp--commit-pre-state :pre-commit-window))
+    (should (eq t (plist-get knayawp--commit-pre-state :active)))
+    (should (windowp (plist-get knayawp--commit-pre-state
+                                :pre-commit-window)))
+    (setq knayawp--commit-pre-state nil)))
+
+(ert-deftest knayawp-test-commit-flow-handler-gating ()
+  "Setup-handler is a no-op when conditions are not met.
+Specifically: (a) no layout active, (b) style is not `zoom', and
+(c) a commit flow is already active."
+  (let ((knayawp--commit-pre-state nil)
+        (knayawp-magit-commit-style 'zoom)
+        (started 0))
+    (cl-letf (((symbol-function 'knayawp--commit-flow-start)
+               (lambda () (cl-incf started))))
+      ;; (a) No layout active: side-window-for-slot returns nil.
+      (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+                 (lambda (_slot) nil)))
+        (knayawp--git-commit-setup-handler)
+        (should (= 0 started)))
+      ;; (b) Style is not `zoom'.
+      (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+                 (lambda (_slot) 'fake-window))
+                ((symbol-function 'knayawp--resolve-commit-style)
+                 (lambda () 'editor)))
+        (knayawp--git-commit-setup-handler)
+        (should (= 0 started)))
+      ;; (c) Commit flow already active.
+      (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+                 (lambda (_slot) 'fake-window))
+                ((symbol-function 'knayawp--resolve-commit-style)
+                 (lambda () 'zoom)))
+        (setq knayawp--commit-pre-state (list :active t))
+        (knayawp--git-commit-setup-handler)
+        (should (= 0 started))
+        (setq knayawp--commit-pre-state nil))
+      ;; Sanity: when all three conditions hold, the handler fires.
+      (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+                 (lambda (_slot) 'fake-window))
+                ((symbol-function 'knayawp--resolve-commit-style)
+                 (lambda () 'zoom)))
+        (knayawp--git-commit-setup-handler)
+        (should (= 1 started))))))
+
+(ert-deftest knayawp-test-commit-flow-end-idempotent ()
+  "Calling `knayawp--commit-flow-end' twice does not error.
+The first call clears state and selects the focus target; the
+second call is a no-op because no flow is active."
+  (let ((knayawp--commit-pre-state
+         (list :active t :was-zoomed nil
+               :prior-magit-buf nil
+               :pre-commit-window (selected-window)))
+        (restored 0))
+    (cl-letf (((symbol-function 'knayawp--restore-commit-pre-state)
+               (lambda ()
+                 (cl-incf restored)
+                 (setq knayawp--commit-pre-state nil))))
+      (knayawp--commit-flow-end)
+      (should (= 1 restored))
+      ;; Second call: state is nil, so restore must not be called.
+      (knayawp--commit-flow-end)
+      (should (= 1 restored)))))
+
+(ert-deftest knayawp-test-commit-pre-state-cleared-by-teardown ()
+  "`knayawp-layout-teardown' clears `knayawp--commit-pre-state'."
+  (let ((knayawp--commit-pre-state
+         (list :active t :was-zoomed nil
+               :prior-magit-buf nil
+               :pre-commit-window (selected-window)))
+        (knayawp--frame-widths nil)
+        (knayawp--magit-saved-display-fn nil)
+        (knayawp--commit-display-entry nil)
+        (knayawp--process-display-entry nil)
+        (knayawp--commit-hooks-installed nil))
+    (cl-letf (((symbol-function 'knayawp--teardown-magit-integration)
+               #'ignore)
+              ((symbol-function 'knayawp--side-windows)
+               (lambda () nil)))
+      (knayawp-layout-teardown))
+    (should-not knayawp--commit-pre-state)))
+
 ;;; knayawp-test.el ends here

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -874,7 +874,10 @@ Setup installs no COMMIT_EDITMSG entry and no commit hooks."
         (setq magit-display-buffer-function original)))))
 
 (ert-deftest knayawp-test-commit-hooks-installed-when-zoom ()
-  "With style = `zoom', setup installs all three commit hooks."
+  "With style = `zoom', setup installs all four commit hooks.
+Also asserts that `server-switch-hook' is APPENDED — its entry
+must land after any pre-existing entries so `knayawp's late
+focus-grab runs after `magit-commit-diff-while-committing'."
   (when (require 'magit nil t)
     (let ((original magit-display-buffer-function)
           (knayawp--magit-saved-display-fn nil)
@@ -887,6 +890,9 @@ Setup installs no COMMIT_EDITMSG entry and no commit hooks."
           (git-commit-setup-hook nil)
           (with-editor-post-finish-hook nil)
           (with-editor-post-cancel-hook nil)
+          ;; Seed `server-switch-hook' with a sentinel so we can
+          ;; verify the knayawp handler is appended after it.
+          (server-switch-hook '(ignore))
           (display-buffer-alist nil))
       (unwind-protect
           (progn
@@ -897,12 +903,17 @@ Setup installs no COMMIT_EDITMSG entry and no commit hooks."
                           with-editor-post-finish-hook))
             (should (memq #'knayawp--with-editor-cancel-handler
                           with-editor-post-cancel-hook))
+            (should (memq #'knayawp--server-switch-handler
+                          server-switch-hook))
+            ;; Sentinel must precede the knayawp entry: appended.
+            (should (equal (last server-switch-hook)
+                           (list #'knayawp--server-switch-handler)))
             (should knayawp--commit-hooks-installed))
         (knayawp--teardown-magit-integration)
         (setq magit-display-buffer-function original)))))
 
 (ert-deftest knayawp-test-commit-hooks-removed-on-teardown ()
-  "Teardown unregisters all three commit-flow handlers."
+  "Teardown unregisters all four commit-flow handlers."
   (when (require 'magit nil t)
     (let ((original magit-display-buffer-function)
           (knayawp--magit-saved-display-fn nil)
@@ -915,6 +926,7 @@ Setup installs no COMMIT_EDITMSG entry and no commit hooks."
           (git-commit-setup-hook nil)
           (with-editor-post-finish-hook nil)
           (with-editor-post-cancel-hook nil)
+          (server-switch-hook nil)
           (display-buffer-alist nil))
       (unwind-protect
           (progn
@@ -926,24 +938,38 @@ Setup installs no COMMIT_EDITMSG entry and no commit hooks."
                               with-editor-post-finish-hook))
             (should-not (memq #'knayawp--with-editor-cancel-handler
                               with-editor-post-cancel-hook))
+            (should-not (memq #'knayawp--server-switch-handler
+                              server-switch-hook))
             (should-not knayawp--commit-hooks-installed))
         (setq magit-display-buffer-function original)))))
 
 (ert-deftest knayawp-test-commit-pre-state-shape ()
   "`knayawp--save-commit-pre-state' populates all expected plist keys."
   (let ((knayawp--commit-pre-state nil)
-        (knayawp--zoomed-panel nil))
-    (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
-               (lambda (_slot) nil)))
-      (knayawp--save-commit-pre-state -1))
-    (should (plist-member knayawp--commit-pre-state :active))
-    (should (plist-member knayawp--commit-pre-state :was-zoomed))
-    (should (plist-member knayawp--commit-pre-state :prior-magit-buf))
-    (should (plist-member knayawp--commit-pre-state :pre-commit-window))
-    (should (eq t (plist-get knayawp--commit-pre-state :active)))
-    (should (windowp (plist-get knayawp--commit-pre-state
-                                :pre-commit-window)))
-    (setq knayawp--commit-pre-state nil)))
+        (knayawp--zoomed-panel nil)
+        (fake-commit-buf (generate-new-buffer " *knayawp-test-commit*")))
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+                     (lambda (_slot) nil)))
+            (knayawp--save-commit-pre-state -1 fake-commit-buf))
+          (should (plist-member knayawp--commit-pre-state :active))
+          (should (plist-member knayawp--commit-pre-state :was-zoomed))
+          (should (plist-member knayawp--commit-pre-state
+                                :prior-magit-buf))
+          (should (plist-member knayawp--commit-pre-state
+                                :commit-buffer))
+          (should (plist-member knayawp--commit-pre-state
+                                :pre-commit-window))
+          (should (eq t (plist-get knayawp--commit-pre-state :active)))
+          (should (eq fake-commit-buf
+                      (plist-get knayawp--commit-pre-state
+                                 :commit-buffer)))
+          (should (windowp (plist-get knayawp--commit-pre-state
+                                      :pre-commit-window))))
+      (setq knayawp--commit-pre-state nil)
+      (when (buffer-live-p fake-commit-buf)
+        (kill-buffer fake-commit-buf)))))
 
 (ert-deftest knayawp-test-commit-flow-handler-gating ()
   "Setup-handler is a no-op when conditions are not met.
@@ -1019,5 +1045,64 @@ second call is a no-op because no flow is active."
                (lambda () nil)))
       (knayawp-layout-teardown))
     (should-not knayawp--commit-pre-state)))
+
+(ert-deftest knayawp-test-server-switch-handler-reasserts-commit ()
+  "`knayawp--server-switch-handler' re-selects COMMIT_EDITMSG.
+Simulates the magit-commit-diff-while-committing race: the magit
+slot's buffer has been displaced by a stand-in `*magit-diff*' and
+focus has wandered.  After the handler runs the magit window
+must show the recorded COMMIT_EDITMSG buffer again, and the
+magit window must be the selected window.
+
+Reproduces the scenario found during manual scenario 1 of PR
+#76 review (focus landing on the diff instead of the commit
+message)."
+  (let* ((commit-buf
+          (generate-new-buffer " *knayawp-test-COMMIT_EDITMSG*"))
+         (diff-buf
+          (generate-new-buffer " *knayawp-test-magit-diff*"))
+         (fake-magit-win (selected-window))
+         (selected nil)
+         (knayawp--commit-pre-state
+          (list :active t
+                :was-zoomed nil
+                :prior-magit-buf nil
+                :commit-buffer commit-buf
+                :pre-commit-window fake-magit-win)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+                   (lambda (_slot) fake-magit-win))
+                  ((symbol-function 'set-window-buffer)
+                   (lambda (_win buf) (setq selected buf)))
+                  ((symbol-function 'select-window)
+                   (lambda (win &optional _norecord)
+                     (setq fake-magit-win win)
+                     win)))
+          ;; Simulate the race: the slot has been clobbered by the
+          ;; diff buffer and focus has drifted there.
+          (setq selected diff-buf)
+          (knayawp--server-switch-handler)
+          (should (eq selected commit-buf))
+          (should (eq fake-magit-win (selected-window))))
+      (when (buffer-live-p commit-buf) (kill-buffer commit-buf))
+      (when (buffer-live-p diff-buf) (kill-buffer diff-buf)))))
+
+(ert-deftest knayawp-test-server-switch-handler-noop-without-flow ()
+  "`knayawp--server-switch-handler' does nothing when idle.
+With no commit-flow session active the handler must not touch
+`set-window-buffer' or `select-window' — the hook runs on every
+emacsclient invocation so a stray side effect would be system-wide."
+  (let ((knayawp--commit-pre-state nil)
+        (touched 0))
+    (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+               (lambda (_slot)
+                 (cl-incf touched)
+                 (selected-window)))
+              ((symbol-function 'set-window-buffer)
+               (lambda (&rest _) (cl-incf touched)))
+              ((symbol-function 'select-window)
+               (lambda (&rest _) (cl-incf touched))))
+      (knayawp--server-switch-handler)
+      (should (= 0 touched)))))
 
 ;;; knayawp-test.el ends here

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -1105,4 +1105,134 @@ emacsclient invocation so a stray side effect would be system-wide."
       (knayawp--server-switch-handler)
       (should (= 0 touched)))))
 
+(ert-deftest knayawp-test-restore-commit-pre-state-resets-zoomed-panel ()
+  "`knayawp--restore-commit-pre-state' resets `knayawp--zoomed-panel'.
+Bug B (round 2 of PR #76 sandbox testing): after the first
+commit, `knayawp--zoomed-panel' was left at `magit', so the
+second commit's `knayawp--save-commit-pre-state' recorded
+`:was-zoomed t' and the flow skipped the zoom step.
+
+Two sub-cases:
+
+1. The pre-flow zoom was `terminal' (a legitimate manual zoom);
+   restore must put `knayawp--zoomed-panel' back to `terminal',
+   not nil.
+
+2. The pre-flow zoom was nil (no manual zoom); restore must put
+   `knayawp--zoomed-panel' back to nil so the next commit's zoom
+   step is allowed to fire."
+  ;; Sub-case 1: manual zoom pre-existed the flow.
+  (let ((knayawp--zoomed-panel 'terminal)
+        (knayawp--commit-pre-state nil))
+    (cl-letf (((symbol-function 'knayawp--focus-target-window)
+               (lambda () nil))
+              ((symbol-function 'knayawp--side-window-for-slot)
+               (lambda (_slot) nil)))
+      ;; Simulate the flow entry: save records `:was-zoomed 'terminal',
+      ;; then the zoom step is skipped (manual zoom already active) but
+      ;; `knayawp--zoomed-panel' stays at `terminal'.
+      (knayawp--save-commit-pre-state -1 nil)
+      (should (eq 'terminal
+                  (plist-get knayawp--commit-pre-state :was-zoomed)))
+      (knayawp--restore-commit-pre-state)
+      (should (eq 'terminal knayawp--zoomed-panel))
+      (should-not knayawp--commit-pre-state)))
+  ;; Sub-case 2: no manual zoom pre-existed.  Simulate Bug B's first
+  ;; commit: enter the flow (zoom is applied, sets the panel to
+  ;; `magit'), then restore must reset to nil.
+  (let ((knayawp--zoomed-panel nil)
+        (knayawp--commit-pre-state nil))
+    (cl-letf (((symbol-function 'knayawp--focus-target-window)
+               (lambda () nil))
+              ((symbol-function 'knayawp--side-window-for-slot)
+               (lambda (_slot) nil)))
+      (knayawp--save-commit-pre-state -1 nil)
+      (should-not (plist-get knayawp--commit-pre-state :was-zoomed))
+      ;; Imitate `knayawp--apply-zoom-solo-magit' side-effect.
+      (setq knayawp--zoomed-panel 'magit)
+      (knayawp--restore-commit-pre-state)
+      (should-not knayawp--zoomed-panel)
+      (should-not knayawp--commit-pre-state))))
+
+(ert-deftest knayawp-test-restore-commit-pre-state-redisplays-magit-status ()
+  "`knayawp--restore-commit-pre-state' re-displays magit-status.
+Bug A (round 2 of PR #76 sandbox testing): the
+`with-editor-previous-winconf' snapshot captured by
+`magit-commit-create' already contains `*magit-diff*' in the
+magit slot (the diff is shown synchronously before `with-editor'
+is invoked), so when `with-editor-return' restores the
+configuration on finish the user sees `*magit-diff*' where they
+expect magit-status.
+
+The restore step looks up the project's status buffer via
+`magit-mode-get-buffer' and re-displays it in the slot.  When the
+user was in a manual zoom before the flow, the slot is theirs and
+we must not touch it.
+
+Two sub-cases:
+
+1. `:was-zoomed' nil and status buffer is live: the slot's
+   `window-buffer' becomes the status buffer.
+
+2. `:was-zoomed' non-nil: the slot's buffer is left untouched."
+  ;; Sub-case 1: slot updated to magit-status.
+  (let* ((diff-buf
+          (generate-new-buffer " *knayawp-test-magit-diff*"))
+         (status-buf
+          (generate-new-buffer " *knayawp-test-magit-status*"))
+         (fake-magit-win (selected-window))
+         (slot-buffer diff-buf)
+         (knayawp--zoomed-panel nil)
+         (knayawp--commit-pre-state
+          (list :active t
+                :was-zoomed nil
+                :prior-magit-buf nil
+                :commit-buffer nil
+                :pre-commit-window fake-magit-win)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+                   (lambda (_slot) fake-magit-win))
+                  ((symbol-function 'window-live-p)
+                   (lambda (_win) t))
+                  ((symbol-function 'magit-mode-get-buffer)
+                   (lambda (_mode) status-buf))
+                  ((symbol-function 'set-window-buffer)
+                   (lambda (_win buf) (setq slot-buffer buf)))
+                  ((symbol-function 'knayawp--focus-target-window)
+                   (lambda () nil)))
+          (knayawp--restore-commit-pre-state)
+          (should (eq slot-buffer status-buf)))
+      (when (buffer-live-p diff-buf) (kill-buffer diff-buf))
+      (when (buffer-live-p status-buf) (kill-buffer status-buf))))
+  ;; Sub-case 2: `:was-zoomed' truthy means the user had a manual
+  ;; zoom active; do not change the slot buffer.
+  (let* ((diff-buf
+          (generate-new-buffer " *knayawp-test-magit-diff-2*"))
+         (status-buf
+          (generate-new-buffer " *knayawp-test-magit-status-2*"))
+         (fake-magit-win (selected-window))
+         (slot-buffer diff-buf)
+         (knayawp--zoomed-panel 'terminal)
+         (knayawp--commit-pre-state
+          (list :active t
+                :was-zoomed 'terminal
+                :prior-magit-buf nil
+                :commit-buffer nil
+                :pre-commit-window fake-magit-win)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'knayawp--side-window-for-slot)
+                   (lambda (_slot) fake-magit-win))
+                  ((symbol-function 'window-live-p)
+                   (lambda (_win) t))
+                  ((symbol-function 'magit-mode-get-buffer)
+                   (lambda (_mode) status-buf))
+                  ((symbol-function 'set-window-buffer)
+                   (lambda (_win buf) (setq slot-buffer buf)))
+                  ((symbol-function 'knayawp--focus-target-window)
+                   (lambda () nil)))
+          (knayawp--restore-commit-pre-state)
+          (should (eq slot-buffer diff-buf)))
+      (when (buffer-live-p diff-buf) (kill-buffer diff-buf))
+      (when (buffer-live-p status-buf) (kill-buffer status-buf)))))
+
 ;;; knayawp-test.el ends here

--- a/test/knayawp-test.el
+++ b/test/knayawp-test.el
@@ -1316,4 +1316,143 @@ the restore on mismatch."
       (knayawp--restore-commit-pre-state)
       (should (eq called-with 'unset)))))
 
+;;;; Commit-style reconcile (#76 follow-up)
+
+(ert-deftest knayawp-test-reconcile-zoom-to-editor ()
+  "Reconcile drops zoom hooks and installs the COMMIT_EDITMSG entry.
+Models the runtime path that the scenario-2 probe exposed: setup
+ran under `zoom', the user then changed `knayawp-magit-commit-style'
+to `editor', and the integration must reflect the new style."
+  (when (require 'magit nil t)
+    (let ((original magit-display-buffer-function)
+          (knayawp--magit-saved-display-fn nil)
+          (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
+          (knayawp--commit-hooks-installed nil)
+          (knayawp--commit-style-shim-warned t)
+          (knayawp-magit-commit-style 'zoom)
+          (git-commit-setup-hook nil)
+          (with-editor-post-finish-hook nil)
+          (with-editor-post-cancel-hook nil)
+          (server-switch-hook nil)
+          (display-buffer-alist nil))
+      (unwind-protect
+          (progn
+            (knayawp--setup-magit-integration)
+            ;; Sanity: zoom state installed, editor entry absent.
+            (should knayawp--commit-hooks-installed)
+            (should-not knayawp--commit-display-entry)
+            ;; Flip the style and reconcile.
+            (setq knayawp-magit-commit-style 'editor)
+            (knayawp--reconcile-commit-style)
+            (should-not knayawp--commit-hooks-installed)
+            (should-not (memq #'knayawp--git-commit-setup-handler
+                              git-commit-setup-hook))
+            (should knayawp--commit-display-entry)
+            (should (memq knayawp--commit-display-entry
+                          display-buffer-alist)))
+        (knayawp--teardown-magit-integration)
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-reconcile-zoom-to-off ()
+  "Reconcile under `off' removes hooks AND the COMMIT_EDITMSG entry."
+  (when (require 'magit nil t)
+    (let ((original magit-display-buffer-function)
+          (knayawp--magit-saved-display-fn nil)
+          (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
+          (knayawp--commit-hooks-installed nil)
+          (knayawp--commit-style-shim-warned t)
+          (knayawp-magit-commit-style 'zoom)
+          (git-commit-setup-hook nil)
+          (with-editor-post-finish-hook nil)
+          (with-editor-post-cancel-hook nil)
+          (server-switch-hook nil)
+          (display-buffer-alist nil))
+      (unwind-protect
+          (progn
+            (knayawp--setup-magit-integration)
+            (should knayawp--commit-hooks-installed)
+            (setq knayawp-magit-commit-style 'off)
+            (knayawp--reconcile-commit-style)
+            (should-not knayawp--commit-hooks-installed)
+            (should-not knayawp--commit-display-entry))
+        (knayawp--teardown-magit-integration)
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-reconcile-idempotent ()
+  "Reconcile is a no-op when the resolved style has not changed."
+  (when (require 'magit nil t)
+    (let ((original magit-display-buffer-function)
+          (knayawp--magit-saved-display-fn nil)
+          (knayawp--commit-display-entry nil)
+          (knayawp--process-display-entry nil)
+          (knayawp--commit-hooks-installed nil)
+          (knayawp--commit-style-shim-warned t)
+          (knayawp-magit-commit-style 'editor)
+          (knayawp-magit-commit-in-editor-flag nil)
+          (display-buffer-alist nil))
+      (unwind-protect
+          (progn
+            (knayawp--setup-magit-integration)
+            (let ((entry knayawp--commit-display-entry))
+              (should entry)
+              ;; Second reconcile must not duplicate or drop the entry.
+              (knayawp--reconcile-commit-style)
+              (should (eq entry knayawp--commit-display-entry))
+              (should (= 1 (cl-count-if
+                            (lambda (e)
+                              (and (stringp (car e))
+                                   (string-match-p "COMMIT_EDITMSG"
+                                                   (car e))))
+                            display-buffer-alist)))))
+        (knayawp--teardown-magit-integration)
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-commit-style-setter-reconciles-when-active ()
+  "Setting via `customize-set-variable' reconciles when active.
+Gates on `magit-display-buffer-function' being knayawp's: this is
+the only honest signal that the magit integration is currently
+installed."
+  (when (require 'magit nil t)
+    (let* ((calls 0)
+           (saved-style (default-value 'knayawp-magit-commit-style))
+           (original magit-display-buffer-function))
+      (unwind-protect
+          (cl-letf (((symbol-function 'knayawp--reconcile-commit-style)
+                     (lambda () (setq calls (1+ calls)))))
+            ;; Active integration: setter must reconcile.
+            (setq magit-display-buffer-function
+                  #'knayawp--magit-display-buffer)
+            (customize-set-variable 'knayawp-magit-commit-style 'editor)
+            (should (= 1 calls))
+            (customize-set-variable 'knayawp-magit-commit-style 'off)
+            (should (= 2 calls)))
+        (customize-set-variable 'knayawp-magit-commit-style saved-style)
+        (setq magit-display-buffer-function original)))))
+
+(ert-deftest knayawp-test-commit-style-setter-passive-when-inactive ()
+  "Setter is a no-op when no magit integration is installed.
+Loading the package and tweaking the option without ever calling
+`knayawp-layout-setup' must not install hooks or entries (P7
+passive-loading discipline carries through to the customize path)."
+  (let* ((calls 0)
+         (saved-style (default-value 'knayawp-magit-commit-style))
+         (original (and (boundp 'magit-display-buffer-function)
+                        magit-display-buffer-function)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'knayawp--reconcile-commit-style)
+                   (lambda () (setq calls (1+ calls)))))
+          ;; No integration: ensure the display-buffer-function is NOT
+          ;; knayawp's, regardless of test ordering.
+          (setq magit-display-buffer-function
+                (or original #'ignore))
+          (customize-set-variable 'knayawp-magit-commit-style 'editor)
+          (customize-set-variable 'knayawp-magit-commit-style 'zoom)
+          (customize-set-variable 'knayawp-magit-commit-style 'off)
+          (should (zerop calls)))
+      (customize-set-variable 'knayawp-magit-commit-style saved-style)
+      (when original
+        (setq magit-display-buffer-function original)))))
+
 ;;; knayawp-test.el ends here

--- a/test/probes/commit-flow-delete-other-windows.el
+++ b/test/probes/commit-flow-delete-other-windows.el
@@ -1,0 +1,99 @@
+;;; commit-flow-delete-other-windows.el --- Commit-flow regression: C-x 1 -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Commit-flow regression probe (`C-x 1' mid-commit).  Run via the suite
+;; (test/run-probes.sh) or:
+;;   test/run-probe.sh test/probes/commit-flow-delete-other-windows.el
+;;
+;; Scenario 4 — `C-x 1' mid-commit (`zoom' style).  With the magit slot
+;; zoomed and showing COMMIT_EDITMSG, the user presses `C-x 1'.  The
+;; protected magit slot must survive; on finish, knayawp's self-captured
+;; winconf must restore the full 3-panel layout with the magit slot back
+;; to magit-status.
+;;
+;; Note on `C-x 1': focus mid-commit is inside COMMIT_EDITMSG, which is a
+;; side window, so `delete-other-windows' there signals "Cannot make side
+;; window the only window" and is a no-op.  This probe records the actual
+;; effect (window count + any error) rather than assuming the editor pane
+;; is deleted; the load-bearing invariant is that the protected slot
+;; survives and the winconf restore later rebuilds the layout (PROBE C).
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defun pr76-s4--probe-a ()
+  "PROBE A — mid-commit, before `C-x 1'."
+  (knayawp-probe-section "PROBE A -- mid-commit, before C-x 1")
+  (let* ((win (get-buffer-window "COMMIT_EDITMSG")))
+    (knayawp-probe-log "  windows: %S" (knayawp-probe-window-summary))
+    (knayawp-probe-check "commit-flow-active" t
+                         (knayawp--commit-flow-active-p))
+    (knayawp-probe-check "commit-win-no-delete-other" t
+                         (and win (window-parameter
+                                   win 'no-delete-other-windows)))
+    (knayawp-probe-check "commit-win-selected" t
+                         (eq win (selected-window)))))
+
+(defun pr76-s4--simulate-cx1 ()
+  "Simulate `C-x 1' from the COMMIT_EDITMSG window; record the effect."
+  (knayawp-probe-section "C-x 1 -- delete-other-windows from commit window")
+  (let* ((win (get-buffer-window "COMMIT_EDITMSG"))
+         (err nil))
+    (when (window-live-p win) (select-window win))
+    (condition-case e (delete-other-windows)
+      (error (setq err e)))
+    (knayawp-probe-log "  cx1-error=%S n-windows=%d windows=%S"
+                       err (length (window-list))
+                       (knayawp-probe-window-summary))
+    ;; Load-bearing invariant: the protected magit slot survived.
+    (knayawp-probe-check "magit-slot-survived" t
+                         (and (window-live-p
+                               (get-buffer-window "COMMIT_EDITMSG"))
+                              t))))
+
+(defun pr76-s4--mid ()
+  "Mid-flow step: PROBE A, then `C-x 1'."
+  (pr76-s4--probe-a)
+  (pr76-s4--simulate-cx1))
+
+(defun pr76-s4--probe-c ()
+  "PROBE C — post-finish; winconf restore must rebuild the layout."
+  (knayawp-probe-section "PROBE C -- post-finish (winconf restore)")
+  (let* ((spec (assq 'magit knayawp-panels))
+         (slot (and spec (knayawp--panel-slot spec)))
+         (mwin (and slot (knayawp--side-window-for-slot slot)))
+         (mbuf (and mwin (buffer-name (window-buffer mwin)))))
+    (knayawp-probe-log "  windows: %S" (knayawp-probe-window-summary))
+    (knayawp-probe-log "  magit-slot-buf=%S" mbuf)
+    (knayawp-probe-check "commit-flow-inactive" nil
+                         (knayawp--commit-flow-active-p))
+    (knayawp-probe-check "commit-buf-gone" nil
+                         (and (get-buffer "COMMIT_EDITMSG") t))
+    (knayawp-probe-check "zoomed-nil" nil knayawp--zoomed-panel)
+    (knayawp-probe-check "side-window-count" 3
+                         (length (knayawp-probe-side-windows)))
+    ;; Bug A guard: the magit slot shows magit-status, not *magit-diff*.
+    (knayawp-probe-check "magit-slot-is-status" t
+                         (and mbuf (string-prefix-p "magit: " mbuf) t))
+    ;; focus-after defaults to editor => selected window is not a side.
+    (knayawp-probe-check "focus-on-editor" nil
+                         (window-parameter (selected-window)
+                                           'window-side)))
+  (knayawp-probe-finish))
+
+(knayawp-probe-watchdog 60)
+
+(condition-case e
+    (let ((default-directory (file-name-as-directory sandbox--test-dir)))
+      (knayawp-mode 1)
+      (setq knayawp-magit-commit-style 'zoom)
+      (knayawp-layout-setup))
+  (error (knayawp-probe-abort "setup failed: %S" e)))
+
+;; Drive the commit: knayawp auto-zooms on setup; our mid step probes and
+;; presses C-x 1; PROBE C checks the restore after finish.
+(knayawp-probe-drive-commit #'pr76-s4--mid #'pr76-s4--probe-c)
+
+;;; commit-flow-delete-other-windows.el ends here

--- a/test/probes/commit-flow-editor-style.el
+++ b/test/probes/commit-flow-editor-style.el
@@ -1,0 +1,94 @@
+;;; commit-flow-editor-style.el --- Commit-flow regression: editor style -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Commit-flow regression probe (`editor' style).  Run via the suite
+;; (test/run-probes.sh) or individually with:
+;;
+;;   test/run-probe.sh test/probes/commit-flow-editor-style.el
+;;
+;; Scenario 2 — `editor' commit style.  With the resolved style
+;; `editor', the reconcile fix (585ffec) must INSTALL the COMMIT_EDITMSG
+;; `display-buffer-alist' entry and REMOVE the zoom commit-flow hooks.
+;; The commit message buffer should then land in the editor pane, not a
+;; side slot, and tearing the commit down must leave a coherent layout.
+;;
+;; The check expectations below are copied from the documented
+;; "EXPECTED (post-fix)" blocks in the interactive probe.  Where the
+;; recorded manual run disagreed with that oracle (PROBE B placement),
+;; this probe still asserts the documented expectation so the harness
+;; reports the discrepancy honestly rather than rubber-stamping it.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defvar pr76-s2--message "probe: stub commit message\n"
+  "Commit message inserted into COMMIT_EDITMSG during the probe.")
+
+;;;; Probe points
+
+(defun pr76-s2--probe-a ()
+  "PROBE A — state right after `knayawp-layout-setup' (style editor)."
+  (knayawp-probe-section "PROBE A -- post-setup state (style=editor)")
+  (knayawp-probe-check "mode" t knayawp-mode)
+  (knayawp-probe-check "style" 'editor knayawp-magit-commit-style)
+  (knayawp-probe-check "resolved" 'editor (knayawp--resolve-commit-style))
+  (knayawp-probe-check "entry-installed" t
+                       (and knayawp--commit-display-entry t))
+  (knayawp-probe-check "hooks-installed" nil
+                       knayawp--commit-hooks-installed)
+  (knayawp-probe-check "magit-display-fn" t
+                       (eq magit-display-buffer-function
+                           #'knayawp--magit-display-buffer)))
+
+(defun pr76-s2--probe-b ()
+  "PROBE B — state while COMMIT_EDITMSG is displayed, before finish."
+  (knayawp-probe-section "PROBE B -- mid-commit (COMMIT_EDITMSG shown)")
+  (let* ((win (get-buffer-window "COMMIT_EDITMSG"))
+         (side (and win (window-parameter win 'window-side)))
+         (slot (and win (window-parameter win 'window-slot))))
+    (knayawp-probe-log "  commit-window=%S side=%S slot=%S" win side slot)
+    (knayawp-probe-log "  windows: %S" (knayawp-probe-window-summary))
+    (knayawp-probe-check "commit-buf-live" t
+                         (and (get-buffer "COMMIT_EDITMSG") t))
+    (knayawp-probe-check "commit-win-live" t (and (window-live-p win) t))
+    ;; Documented oracle: COMMIT_EDITMSG lands in the EDITOR pane
+    ;; (window-side nil), and that window is selected.
+    (knayawp-probe-check "commit-win-side(editor)" nil side)
+    (knayawp-probe-check "commit-win-selected" t (eq win (selected-window)))
+    (knayawp-probe-check "side-window-count" 3
+                         (length (knayawp-probe-side-windows)))))
+
+(defun pr76-s2--probe-c ()
+  "PROBE C — state after the commit is finished."
+  (knayawp-probe-section "PROBE C -- post-finish state")
+  (knayawp-probe-log "  windows: %S" (knayawp-probe-window-summary))
+  (knayawp-probe-check "commit-buf-gone" nil
+                       (and (get-buffer "COMMIT_EDITMSG") t))
+  (knayawp-probe-check "commit-flow-inactive" nil
+                       (knayawp--commit-flow-active-p))
+  (knayawp-probe-check "zoomed-nil" nil knayawp--zoomed-panel)
+  (knayawp-probe-check "side-window-count" 3
+                       (length (knayawp-probe-side-windows)))
+  (knayawp-probe-finish))
+
+;;;; Driver
+
+(knayawp-probe-watchdog 60)
+
+;; Setup: enable mode, select editor commit style, build the layout.
+(condition-case e
+    (progn
+      (knayawp-mode 1)
+      (setq knayawp-magit-commit-style 'editor)
+      (let ((default-directory (file-name-as-directory sandbox--test-dir)))
+        (knayawp-layout-setup))
+      (pr76-s2--probe-a))
+  (error (knayawp-probe-abort "setup failed: %S" e)))
+
+;; Drive the editor-style commit: PROBE B mid-flow, PROBE C on finish.
+(setq knayawp-probe-commit-message pr76-s2--message)
+(knayawp-probe-drive-commit #'pr76-s2--probe-b #'pr76-s2--probe-c)
+
+;;; commit-flow-editor-style.el ends here

--- a/test/probes/commit-flow-manual-zoom.el
+++ b/test/probes/commit-flow-manual-zoom.el
@@ -1,0 +1,72 @@
+;;; commit-flow-manual-zoom.el --- Commit-flow regression: manual zoom -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Commit-flow regression probe (manual zoom mid-commit).  Run via the
+;; suite (test/run-probes.sh) or:
+;;   test/run-probe.sh test/probes/commit-flow-manual-zoom.el
+;;
+;; Scenario 3 — manual zoom mid-commit (`zoom' style).  The user zooms
+;; the magit slot BEFORE committing.  The flow must NOT double-zoom and,
+;; on finish, must NOT re-expand to 3 panels (the manual zoom is the
+;; user's).  Expectations are copied from the interactive probe's
+;; documented EXPECTED / VERDICT blocks.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defun pr76-s3--probe-a ()
+  "PROBE A — after the user manually zooms the magit slot."
+  (knayawp-probe-section "PROBE A -- pre-commit, user manually zoomed")
+  (knayawp-probe-log "  windows: %S" (knayawp-probe-window-summary))
+  (knayawp-probe-check "zoomed" 'magit knayawp--zoomed-panel)
+  (knayawp-probe-check "side-window-count" 1
+                       (length (knayawp-probe-side-windows))))
+
+(defun pr76-s3--probe-b ()
+  "PROBE B — mid-commit; the guard must prevent a double-zoom."
+  (knayawp-probe-section "PROBE B -- mid-commit (no double-zoom)")
+  (let* ((win (get-buffer-window "COMMIT_EDITMSG"))
+         (side (and win (window-parameter win 'window-side))))
+    (knayawp-probe-log "  commit-window=%S side=%S selected-buf=%S"
+                       win side
+                       (buffer-name (window-buffer (selected-window))))
+    (knayawp-probe-check "was-zoomed" 'magit
+                         (plist-get knayawp--commit-pre-state :was-zoomed))
+    (knayawp-probe-check "commit-flow-active" t
+                         (knayawp--commit-flow-active-p))
+    (knayawp-probe-check "zoomed" 'magit knayawp--zoomed-panel)
+    (knayawp-probe-check "commit-win-side" 'right side)
+    (knayawp-probe-check "side-window-count" 1
+                         (length (knayawp-probe-side-windows)))))
+
+(defun pr76-s3--probe-c ()
+  "PROBE C — post-finish; manual zoom preserved, no re-expand."
+  (knayawp-probe-section "PROBE C -- post-finish (manual zoom preserved)")
+  (knayawp-probe-log "  windows: %S" (knayawp-probe-window-summary))
+  (knayawp-probe-check "commit-flow-inactive" nil
+                       (knayawp--commit-flow-active-p))
+  (knayawp-probe-check "zoomed" 'magit knayawp--zoomed-panel)
+  (knayawp-probe-check "side-window-count" 1
+                       (length (knayawp-probe-side-windows)))
+  (knayawp-probe-finish))
+
+(knayawp-probe-watchdog 60)
+
+;; Setup: zoom style, layout, then MANUALLY zoom the magit panel.
+(condition-case e
+    (let ((default-directory (file-name-as-directory sandbox--test-dir)))
+      (knayawp-mode 1)
+      (setq knayawp-magit-commit-style 'zoom)
+      (knayawp-layout-setup)
+      (knayawp-select-panel 1)          ; focus magit
+      (knayawp-zoom-panel)              ; manual zoom
+      (pr76-s3--probe-a))
+  (error (knayawp-probe-abort "setup failed: %S" e)))
+
+;; Drive the commit.  knayawp's own zoom handlers fire first; our probes
+;; (appended) observe the result.
+(knayawp-probe-drive-commit #'pr76-s3--probe-b #'pr76-s3--probe-c)
+
+;;; commit-flow-manual-zoom.el ends here

--- a/test/probes/commit-flow-narrow-frame.el
+++ b/test/probes/commit-flow-narrow-frame.el
@@ -1,0 +1,75 @@
+;;; commit-flow-narrow-frame.el --- Commit-flow regression: narrow frame -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Commit-flow regression probe (narrow frame).  Run via the suite
+;; (test/run-probes.sh) or NARROW, explicitly:
+;;   test/run-probe.sh test/probes/commit-flow-narrow-frame.el 40x50
+;;
+;; Probe-Geometry: 40x50
+;;
+;; Scenario 5 — narrow frame.  At a width where a 3-way side-window split
+;; is implausible, building the layout and attempting a commit must not
+;; silently corrupt the window tree.  Acceptance: every window live, no
+;; degenerate (zero/absurd-width) window, flow state not stuck.  A clean
+;; `user-error' is acceptable and is recorded, not failed.
+;;
+;; Unlike the commit-completing probes, this one does NOT finish the
+;; commit (a narrow frame may make that impossible); it captures
+;; coherence shortly after the attempt and exits.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defvar pr76-s5--setup-error nil "Error signalled by layout-setup, if any.")
+(defvar pr76-s5--commit-error nil "Error signalled by the commit attempt.")
+
+(defun pr76-s5--probe (reason)
+  "Capture coherence of the window tree; REASON labels what triggered it."
+  (unless knayawp-probe--finished
+    (knayawp-probe-section (format "PROBE -- coherence after commit attempt (%s)" reason))
+    (let* ((wins (window-list))
+           (widths (mapcar #'window-width wins))
+           (min-width (apply #'min widths)))
+      (knayawp-probe-log "  frame-width=%d n-windows=%d widths=%S"
+                         (frame-width) (length wins) widths)
+      (knayawp-probe-log "  windows: %S" (knayawp-probe-window-summary))
+      (knayawp-probe-log "  setup-error=%S commit-error=%S"
+                         pr76-s5--setup-error pr76-s5--commit-error)
+      ;; A user-error on either step is acceptable; a Lisp error whose
+      ;; symbol is not `user-error' is treated as a crash.
+      (knayawp-probe-check "setup-clean(no-crash)" t
+                           (or (null pr76-s5--setup-error)
+                               (eq (car pr76-s5--setup-error) 'user-error)))
+      (knayawp-probe-check "commit-clean(no-crash)" t
+                           (or (null pr76-s5--commit-error)
+                               (eq (car pr76-s5--commit-error) 'user-error)))
+      (knayawp-probe-check "all-windows-live" t
+                           (seq-every-p #'window-live-p wins))
+      (knayawp-probe-check "no-degenerate-window" t (> min-width 0))
+      (knayawp-probe-check "flow-not-stuck" t
+                           (or (not (knayawp--commit-flow-active-p))
+                               ;; active is OK only if a real commit buffer
+                               ;; backs it; a stuck flow has none.
+                               (and (get-buffer "COMMIT_EDITMSG") t))))
+    (knayawp-probe-finish)))
+
+(knayawp-probe-watchdog 40)
+
+(condition-case e
+    (let ((default-directory (file-name-as-directory sandbox--test-dir)))
+      (knayawp-mode 1)
+      (setq knayawp-magit-commit-style 'zoom)
+      (condition-case se (knayawp-layout-setup)
+        (error (setq pr76-s5--setup-error se))))
+  (error (knayawp-probe-abort "mode/style setup failed: %S" e)))
+
+;; Attempt the commit; at a narrow width this may error cleanly.
+(condition-case ce (knayawp-probe-stage-and-commit)
+  (error (setq pr76-s5--commit-error ce)))
+
+;; Capture coherence after the attempt has had a moment to unfold.
+(run-with-timer 6 nil (lambda () (pr76-s5--probe "settled")))
+
+;;; commit-flow-narrow-frame.el ends here

--- a/test/probes/commit-flow-off-switch.el
+++ b/test/probes/commit-flow-off-switch.el
@@ -1,0 +1,59 @@
+;;; commit-flow-off-switch.el --- Commit-flow regression: off kill-switch -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Commit-flow regression probe (`off' kill-switch).  Run via the suite
+;; (test/run-probes.sh) or:
+;;   test/run-probe.sh test/probes/commit-flow-off-switch.el
+;;
+;; Scenario 7 — `off' kill-switch.  With `knayawp-magit-commit-style' set
+;; to `off', knayawp installs NO commit-flow hooks and NO COMMIT_EDITMSG
+;; display entry, but keeps `magit-display-buffer-function' routing magit
+;; buffers into the layout.  A commit must complete with knayawp entirely
+;; passive on the commit path.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defun pr76-s7--probe-a ()
+  "PROBE A — post-setup; knayawp passive on the commit path."
+  (knayawp-probe-section "PROBE A -- post-setup state (style=off)")
+  (knayawp-probe-check "style" 'off knayawp-magit-commit-style)
+  (knayawp-probe-check "resolved" 'off (knayawp--resolve-commit-style))
+  (knayawp-probe-check "entry-installed" nil
+                       (and knayawp--commit-display-entry t))
+  (knayawp-probe-check "hooks-installed" nil
+                       knayawp--commit-hooks-installed)
+  (knayawp-probe-check "magit-display-fn" t
+                       (eq magit-display-buffer-function
+                           #'knayawp--magit-display-buffer)))
+
+(defun pr76-s7--probe-b ()
+  "PROBE B — post-commit; knayawp never engaged the flow."
+  (knayawp-probe-section "PROBE B -- post-commit (knayawp stayed passive)")
+  (knayawp-probe-log "  windows: %S" (knayawp-probe-window-summary))
+  (knayawp-probe-check "commit-flow-inactive" nil
+                       (knayawp--commit-flow-active-p))
+  (knayawp-probe-check "commit-pre-state-nil" nil knayawp--commit-pre-state)
+  (knayawp-probe-check "zoomed-nil" nil knayawp--zoomed-panel)
+  (knayawp-probe-check "commit-buf-gone" nil
+                       (and (get-buffer "COMMIT_EDITMSG") t))
+  (knayawp-probe-check "all-windows-live" t
+                       (seq-every-p #'window-live-p (window-list)))
+  (knayawp-probe-finish))
+
+(knayawp-probe-watchdog 60)
+
+(condition-case e
+    (let ((default-directory (file-name-as-directory sandbox--test-dir)))
+      (knayawp-mode 1)
+      (setq knayawp-magit-commit-style 'off)
+      (knayawp-layout-setup)
+      (pr76-s7--probe-a))
+  (error (knayawp-probe-abort "setup failed: %S" e)))
+
+;; A normal commit; no mid probe — knayawp must do nothing special.
+(knayawp-probe-drive-commit nil #'pr76-s7--probe-b)
+
+;;; commit-flow-off-switch.el ends here

--- a/test/probes/commit-flow-reword.el
+++ b/test/probes/commit-flow-reword.el
@@ -1,0 +1,76 @@
+;;; commit-flow-reword.el --- Commit-flow regression: reword via with-editor -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Commit-flow regression probe (reword via with-editor).  Run via the
+;; suite (test/run-probes.sh) or:
+;;   test/run-probe.sh test/probes/commit-flow-reword.el
+;;
+;; Scenario 6 — reword commit message (`zoom' style).  A message buffer
+;; opened by `magit-commit-reword' (the with-editor path through an
+;; amend/rebase, NOT `magit-commit-create') must drive the SAME zoom
+;; flow: zoom fires, the edit buffer is focused in the magit slot, and on
+;; finish the 3-panel layout is restored with the magit slot back to
+;; magit-status.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defun pr76-s6--probe-a ()
+  "PROBE A — reword buffer open; the zoom flow must have engaged."
+  (knayawp-probe-section "PROBE A -- mid-edit (reword buffer open)")
+  (let* ((win (selected-window))
+         (buf (buffer-name (window-buffer win))))
+    (knayawp-probe-log "  edit-buf=%S edit-side=%S windows: %S"
+                       buf (window-parameter win 'window-side)
+                       (knayawp-probe-window-summary))
+    (knayawp-probe-check "commit-flow-active" t
+                         (knayawp--commit-flow-active-p))
+    (knayawp-probe-check "edit-side" 'right
+                         (window-parameter win 'window-side))
+    (knayawp-probe-check "was-zoomed" nil
+                         (plist-get knayawp--commit-pre-state :was-zoomed))
+    (knayawp-probe-check "zoomed" 'magit knayawp--zoomed-panel)
+    (knayawp-probe-check "side-window-count" 1
+                         (length (knayawp-probe-side-windows)))))
+
+(defun pr76-s6--probe-b ()
+  "PROBE B — post-finish; full layout restored, magit-status back."
+  (knayawp-probe-section "PROBE B -- post-finish (layout restored)")
+  (let* ((spec (assq 'magit knayawp-panels))
+         (slot (and spec (knayawp--panel-slot spec)))
+         (mwin (and slot (knayawp--side-window-for-slot slot)))
+         (mbuf (and mwin (buffer-name (window-buffer mwin)))))
+    (knayawp-probe-log "  magit-slot-buf=%S windows: %S"
+                       mbuf (knayawp-probe-window-summary))
+    (knayawp-probe-check "commit-flow-inactive" nil
+                         (knayawp--commit-flow-active-p))
+    (knayawp-probe-check "zoomed-nil" nil knayawp--zoomed-panel)
+    (knayawp-probe-check "side-window-count" 3
+                         (length (knayawp-probe-side-windows)))
+    (knayawp-probe-check "magit-slot-is-status" t
+                         (and mbuf (string-prefix-p "magit: " mbuf) t))
+    (knayawp-probe-check "focus-on-editor" nil
+                         (window-parameter (selected-window)
+                                           'window-side)))
+  (knayawp-probe-finish))
+
+(knayawp-probe-watchdog 60)
+
+(condition-case e
+    (let ((default-directory (file-name-as-directory sandbox--test-dir)))
+      (knayawp-mode 1)
+      (setq knayawp-magit-commit-style 'zoom)
+      (knayawp-layout-setup))
+  (error (knayawp-probe-abort "setup failed: %S" e)))
+
+;; Reword HEAD (the sandbox initial commit) rather than creating a commit.
+(knayawp-probe-drive-commit #'pr76-s6--probe-a #'pr76-s6--probe-b
+                            (lambda ()
+                              (let ((default-directory
+                                     (file-name-as-directory
+                                      sandbox--test-dir)))
+                                (magit-commit-reword))))
+
+;;; commit-flow-reword.el ends here

--- a/test/run-probes.sh
+++ b/test/run-probes.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# test/run-probes.sh — Run the headless probe regression suite.
+#
+# Usage:
+#   test/run-probes.sh [DIR]
+#
+# Runs every `*.el` probe in DIR (default test/probes/) through
+# test/run-probe.sh and prints a one-line STATUS per probe.  Exits
+# non-zero if any probe is not GREEN, so it is usable as a CI gate.
+#
+# A probe may request a specific frame geometry with a header comment:
+#   ;; Probe-Geometry: 40x50
+# Otherwise run-probe.sh's default geometry is used.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIR="${1:-$REPO_ROOT/test/probes}"
+RUNNER="$REPO_ROOT/test/run-probe.sh"
+
+shopt -s nullglob
+probes=("$DIR"/*.el)
+if [ ${#probes[@]} -eq 0 ]; then
+    echo "run-probes: no probes found in $DIR"
+    exit 0
+fi
+
+echo "Running ${#probes[@]} probe(s) from $DIR"
+echo
+
+failures=0
+for probe in "${probes[@]}"; do
+    name="$(basename "$probe")"
+    geom="$(grep -m1 -oE 'Probe-Geometry:[[:space:]]*[0-9]+x[0-9]+' "$probe" \
+                | grep -oE '[0-9]+x[0-9]+' || true)"
+    out="$("$RUNNER" "$probe" ${geom:+"$geom"} 2>&1)"
+    status="$(printf '%s\n' "$out" | grep -oE 'STATUS: [A-Z]+' | tail -1)"
+    result="$(printf '%s\n' "$out" | grep -oE 'RESULT:.*' | tail -1)"
+    printf '%-44s %-18s %s\n' "$name" "${status:-NO-STATUS}" "$result"
+    if ! printf '%s' "$status" | grep -q 'STATUS: GREEN'; then
+        failures=$((failures + 1))
+        echo "----- full output: $name -----"
+        printf '%s\n' "$out"
+        echo "-------------------------------"
+    fi
+done
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "Suite GREEN: all ${#probes[@]} probe(s) passed."
+else
+    echo "Suite RED: $failures of ${#probes[@]} probe(s) failed."
+fi
+exit "$failures"

--- a/test/run-sandbox.sh
+++ b/test/run-sandbox.sh
@@ -2,8 +2,16 @@
 # test/run-sandbox.sh — Launch an isolated Emacs to test knayawp.el live
 #
 # Usage:
-#   ./test/run-sandbox.sh           # GUI Emacs
-#   ./test/run-sandbox.sh -nw       # Terminal Emacs
+#   ./test/run-sandbox.sh                       # GUI Emacs
+#   ./test/run-sandbox.sh -nw                   # Terminal Emacs
+#   ./test/run-sandbox.sh FILE                  # also open FILE (e.g. a probe)
+#   ./test/run-sandbox.sh -nw .tmp/pr76-scenario3-probe.el
+#
+# Any argument starting with "-" is forwarded to Emacs (e.g. -nw).
+# A single non-flag argument is an EXTRA file to open in the sandbox
+# alongside the test project — handy for opening a probe file without
+# typing its absolute path each restart (the sandbox project lives in
+# /tmp, so the probe file is otherwise an awkward C-x C-f away).
 #
 # What it does:
 #   1. Starts Emacs -Q (no user config)
@@ -11,6 +19,8 @@
 #   3. Creates a throwaway git project in /tmp
 #   4. Loads knayawp.el from this repo
 #   5. Opens a test file — ready for M-x knayawp-layout-setup
+#   6. If an EXTRA file was given, opens it too (shown, not selected, so
+#      C-c k l still targets the /tmp sandbox project)
 #
 # The sandbox session is fully disposable.  Close it and re-run
 # this script any time you want a fresh test.
@@ -19,6 +29,34 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-exec emacs -Q "$@" \
+emacs_args=()
+extra_file=""
+for arg in "$@"; do
+  case "$arg" in
+    -*)
+      emacs_args+=("$arg")
+      ;;
+    *)
+      if [[ -n "$extra_file" ]]; then
+        echo "run-sandbox.sh: only one EXTRA file may be given (extra: $arg)" >&2
+        exit 1
+      fi
+      extra_file="$arg"
+      ;;
+  esac
+done
+
+if [[ -n "$extra_file" ]]; then
+  if [[ ! -e "$extra_file" ]]; then
+    echo "run-sandbox.sh: EXTRA file not found: $extra_file" >&2
+    exit 1
+  fi
+  # Resolve to an absolute path: sandbox.el runs with /tmp as its
+  # default-directory, so a relative path would not be found there.
+  extra_file="$(cd "$(dirname "$extra_file")" && pwd)/$(basename "$extra_file")"
+  export KNAYAWP_SANDBOX_EXTRA_FILE="$extra_file"
+fi
+
+exec emacs -Q "${emacs_args[@]+"${emacs_args[@]}"}" \
      --eval "(setq inhibit-splash-screen t)" \
      -l "${REPO_ROOT}/test/sandbox.el"

--- a/test/sandbox.el
+++ b/test/sandbox.el
@@ -16,6 +16,10 @@
 ;; 4. Opens a test file in that project
 ;; 5. Binds C-c k to knayawp-command-map
 ;; 6. Shows a help buffer with commands to try
+;; 7. If KNAYAWP_SANDBOX_EXTRA_FILE is set (run-sandbox.sh FILE), opens
+;;    that file too — shown but NOT selected, so the test file stays
+;;    current and C-c k l targets the /tmp sandbox project, not the
+;;    project the extra file happens to live in.
 ;;
 ;; The temp project is cleaned up when Emacs exits.
 ;;
@@ -119,6 +123,17 @@
     (special-mode))
   (display-buffer help-buf '(display-buffer-at-bottom
                              (window-height . 0.35))))
+
+;;;; Optionally open an extra file (e.g. a probe), without selecting it
+
+;; Selecting it would make it the current buffer, and `knayawp-layout-setup'
+;; resolves the project from the current buffer — so a probe file living in
+;; another repo would hijack the layout.  Display it, keep `hello.el' current.
+(let ((extra (getenv "KNAYAWP_SANDBOX_EXTRA_FILE")))
+  (when (and extra (not (string-empty-p extra)))
+    (if (file-readable-p extra)
+        (display-buffer (find-file-noselect extra))
+      (message "sandbox: extra file not readable — %s" extra))))
 
 (message "sandbox ready — C-c k l to set up the layout")
 


### PR DESCRIPTION
Closes #48
Closes #53

## Summary

- New defcustom `knayawp-magit-commit-style` (three values: `'zoom` default, `'editor` legacy, `'off` kill-switch). Zoom collapses the magit slot to the right column during commit, with COMMIT_EDITMSG focused — fixes #53. The diff briefly lands in the same slot during commit; on commit finish the slot is rewritten to `magit-status` — fixes the symptoms of #48.
- New defcustom `knayawp-magit-commit-focus-after` (`'editor` default, `'magit`, `'previous`) controls where focus lands on commit finish/cancel.
- Obsolescence shim for `knayawp-magit-commit-in-editor-flag`: `make-obsolete-variable` at 0.1.4; the old flag still works when the new var is at its default (`t` → `'editor`, `nil` → `'off`).
- KB delta: new property **P9** (with-editor cooperation — knayawp captures its own pre-flow window configuration and restores from it on commit finish/cancel), `kb/spec.md` gains a "Commit flow" subsection under Feature 1 / Magit integration.
- Forward-compat anchor: `knayawp--apply-zoom-solo-magit` thin wrapper for the v0.3.0 layout-engine refactor (#70 — cross-referenced).
- 16 new ERT tests across four commits under `;;;; Commit flow (#48, #53)` (9 original + 7 added during sandbox-driven fixes).

**Surprise finding from the design pass:** the #48 issue body diagnosed this as `magit-diff-while-committing` bypassing our `magit-display-buffer-function`. That diagnosis is wrong — our function IS on the call stack. The actual symptoms are three compounding effects (COMMIT_EDITMSG via `with-editor-server-window-alist`, diff overwriting status in the same slot, focus race in `magit-display-buffer-noselect`/`server-switch-buffer`). The zoom fix still works, just for different reasons. Full trace in the commit body and in the design doc.

**Self-managed winconf:** `with-editor-previous-winconf` turned out to capture the layout *after* our `git-commit-setup-hook` handler runs — a post-zoom snapshot, unsuitable for restoration (only the magit slot survives in it; terminal and Claude side windows are gone). knayawp now captures its own `(current-window-configuration)` in `knayawp--commit-flow-start` (before the zoom step) and calls `set-window-configuration` on it in `knayawp--restore-commit-pre-state` to override with-editor's stale restore. No advice or rebinding — with-editor's own `set-window-configuration` runs first via `with-editor-return`, and ours runs after through `with-editor-post-finish-hook` / `-cancel-hook`. P9 amended accordingly. See `kb/properties.md`.

**Follow-up: commit-style reconcile (585ffec):** the scenario-2 sandbox probe (`.tmp/pr76-scenario2-probe.el`) caught a second defect in the same setup path. Probe A reported `:hooks-installed t :entry-installed nil :resolved editor` — the zoom commit-flow hooks were still installed after the user switched `knayawp-magit-commit-style` to `'editor`, and the COMMIT_EDITMSG `display-buffer-alist` entry that `'editor` style needs was never installed. Probe B confirmed the user-visible symptom: `COMMIT_EDITMSG` exists but is in no window. Root cause: `knayawp--setup-magit-integration` was install-only — its `pcase` pushed the install bits for the current style but never removed bits left over from a previous style. Plain `setq` on the defcustom was also silent because there was no `:set` form. Fix: new `knayawp--reconcile-commit-style` helper drives the install/remove from both `knayawp--setup-magit-integration` *and* the new `:set` form on `knayawp-magit-commit-style`, so `setopt`/`customize-set-variable` reconcile immediately when the integration is active. New property **P10** in `kb/properties.md` codifies the invariant.

## Test plan

- [x] `emacs -batch -f batch-byte-compile knayawp.el` — zero warnings
- [x] `emacs -batch -l knayawp.el --eval '(checkdoc-file "knayawp.el")'` — clean
- [x] `emacs -batch -l ert -l knayawp.el -l test/knayawp-test.el -f ert-run-tests-batch-and-exit` — 96/96 pass (21 new across 8f6401c/22a06f2/4affca4/11c4c31/585ffec + 75 pre-existing)

### Manual sandbox checklist (7 scenarios)

Each scenario lists explicit expected state at key checkpoints (editor pane + magit slot + terminal slot + Claude slot + focus) so failures are unambiguous. `(length (window-list))` counts below assume no sandbox helper window — add **+1** when run via `./test/run-sandbox.sh`, which opens a `*knayawp-sandbox*` instructions buffer in the editor pane.

- [x] **Scenario 1 — End-to-end zoom (default `'zoom`).** `./test/run-sandbox.sh`, `C-c k l`, edit a file in the editor pane, `C-c k 1` (or `C-x g`) to magit, stage a change, `c c`.
  - *Mid-commit:* one side window (magit slot) showing COMMIT_EDITMSG, focused. Editor pane intact behind. Terminal and Claude slots gone. `(length (window-list))` = 2.
  - *After `C-c C-c`:* 3 side windows restored (magit + terminal + Claude). Magit slot shows `magit-status` (NOT `*magit-diff*`). Focus on editor pane (per default `knayawp-magit-commit-focus-after = 'editor`). `(length (window-list))` = 4.

- [ ] **Scenario 2 — Legacy `'editor` style.** `(setq knayawp-magit-commit-style 'editor)`, then `C-c k l`, stage in magit, `c c`.
  - *Setup:* no commit-flow hooks installed; only a `display-buffer-alist` entry routes `COMMIT_EDITMSG`.
  - *Mid-commit:* 3 side windows intact. Magit slot shows `*magit-diff*`. COMMIT_EDITMSG lands in the editor pane (side windows are dedicated so `display-buffer-use-some-window` picks the editor pane); focus on COMMIT_EDITMSG.
  - *After `C-c C-c`:* `with-editor`'s `set-window-configuration` runs (no knayawp restore in `'editor` mode). Editor pane returns to the previous buffer. **Magit slot still shows `*magit-diff*`** — `'editor` mode does NOT get the magit-status rewrite (intentional: legacy-parity). Terminal and Claude slots intact. `(length (window-list))` = 4.
  - *Acceptance:* no errors, all 3 side windows present after finish, no layout corruption. Slot-shows-diff is acceptable for the legacy path.

- [ ] **Scenario 3 — Manual zoom mid-commit (`'zoom`).** With `'zoom` style and 3-panel layout active, press `C-c k z` to zoom the magit slot manually. Then stage in magit and `c c`.
  - *Pre-commit:* 1 side window (magit slot) zoomed by the user. `knayawp--zoomed-panel = 'magit`.
  - *Mid-commit:* still 1 side window. COMMIT_EDITMSG in the slot, focused. **No double-zoom** — the `:was-zoomed` guard in `knayawp--commit-flow-start` skipped the auto-zoom step.
  - *After `C-c C-c`:* layout returns to the user's manually-zoomed state — 1 side window (magit slot). **No re-expansion to 3-panel** — the manual zoom is the user's; we don't undo it. The slot-magit-status rewrite is skipped because `:was-zoomed` was truthy. `knayawp--zoomed-panel` restored to `'magit`.

- [ ] **Scenario 4 — `C-x 1` mid-commit (`'zoom`).** Scenario 1 setup through the `c c`. Mid-commit, while focused on COMMIT_EDITMSG, press `C-x 1`.
  - *After `C-x 1`:* only the magit slot remains (its `no-delete-other-windows` parameter protects it; the editor pane is deleted). Selected window: COMMIT_EDITMSG in the magit slot.
  - *After `C-c C-c`:* knayawp's captured winconf is restored — 3 side windows back, editor pane back, magit slot rewritten to `magit-status`, focus per `knayawp-magit-commit-focus-after`. `(length (window-list))` = 4.
  - *Acceptance:* full layout recovery; no leftover broken state.

- [ ] **Scenario 5 — Narrow frame.** Resize the frame width so the zoom slot would be uncomfortably narrow. `C-c k l`, attempt a commit.
  - *Acceptance:* no silent layout corruption. A `user-error` is acceptable; a crash or undefined window state is not.

- [ ] **Scenario 6 — Rebase commit-message edit (`'zoom`).** From magit-status, `l l` (log all), select a commit, press `r` (reword) — or use `e` during an interactive rebase. A commit-message buffer opens via `with-editor`.
  - *Mid-edit:* same as Scenario 1 — zoom fires, the edit buffer is focused in the magit slot.
  - *After `C-c C-c`:* same as Scenario 1 — 3 side windows restored, magit slot back to `magit-status`, focus on editor.

- [ ] **Scenario 7 — `'off` kill-switch.** `(setq knayawp-magit-commit-style 'off)`, then `C-c k l`, stage in magit, `c c`.
  - *Setup:* no commit-flow hooks, no COMMIT_EDITMSG `display-buffer-alist` entry. `magit-display-buffer-function` still routes magit buffers; everything else follows magit/with-editor defaults.
  - *Acceptance:* commit completes without errors from knayawp. The commit flow's window behavior is governed entirely by magit/with-editor defaults — knayawp is passive on the commit path.


