### PR TITLE
chore: MIT licence and full authorship attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Germán Delbianco
+Copyright (c) 2026 Germán Andrés Delbianco <knayawp@proton.me>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/knayawp.el
+++ b/knayawp.el
@@ -1,11 +1,15 @@
 ;;; knayawp.el --- Project-oriented window layouts for Emacs -*- lexical-binding: t; -*-
 
-;; Author: Germán Andrés Delbianco <knayawp@gmail.com>
-;; Maintainer: Germán Andrés Delbianco <knayawp@gmail.com>
+;; Author: Germán Andrés Delbianco <knayawp@proton.me>
+;; Maintainer: Germán Andrés Delbianco <knayawp@proton.me>
 ;; Version: 0.1.3
 ;; Package-Requires: ((emacs "29.1") (magit "3.0"))
 ;; Keywords: frames, convenience
 ;; URL: https://github.com/germanD/knayawp.el
+
+;; Copyright (C) 2026 Germán Andrés Delbianco <knayawp@proton.me>
+
+;; SPDX-License-Identifier: MIT
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
## Summary
- **LICENSE**: copyright updated to full name "Germán Andrés Delbianco" and proton.me email
- **knayawp.el**: `Author`/`Maintainer` headers updated to proton.me address
- **knayawp.el**: added `Copyright` line and `SPDX-License-Identifier: MIT` header (standard for MELPA-eligible packages)

## Test plan
- [x] `emacs -batch -f batch-byte-compile knayawp.el` — zero warnings
- [x] `checkdoc` — clean
- No behaviour changes; pure metadata update

Closes N/A — IP ownership resolved, all clear to publish under MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)